### PR TITLE
use js date to avoid timestamp with sqlite date obj

### DIFF
--- a/src/server/api/routers/post.ts
+++ b/src/server/api/routers/post.ts
@@ -35,12 +35,17 @@ export const postRouter = createTRPCRouter({
         });
       }
 
+      const currentDate = new Date();
+      const stringDate = currentDate.toISOString();
+
       try {
         await ctx.db.insert(posts).values({
           name: input.name,
           description: input.description,
           bucketUrl: input.nanoid,
           clerkUserId: userId,
+          dateCreated: stringDate,
+          dateUpdated: stringDate,
         });
       } catch (err) {
         if (err instanceof Error) {
@@ -51,6 +56,8 @@ export const postRouter = createTRPCRouter({
               description: input.description,
               bucketUrl: input.nanoid,
               clerkUserId: userId,
+              dateCreated: stringDate,
+              dateUpdated: stringDate,
             });
           }
         }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -13,12 +13,8 @@ export const posts = sqliteTable(
     id: integer().primaryKey().unique(),
     name: text(),
     description: text(),
-    dateCreated: text("date_created")
-      .notNull()
-      .default(sql`(current_timestamp)`),
-    dateUpdated: text("date_updated")
-      .notNull()
-      .default(sql`(current_timestamp)`),
+    dateCreated: text("date_created").notNull(),
+    dateUpdated: text("date_updated").notNull(),
     bucketUrl: text().notNull(),
     clerkUserId: text(),
     isPublicShared: integer({ mode: "boolean" }).default(false),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that the creation and update timestamps for new posts are always accurately recorded when a post is added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->