### PR TITLE
Prefill card name from script nickName on single-component paste

### DIFF
--- a/src/app/components/add-gh-dialog.tsx
+++ b/src/app/components/add-gh-dialog.tsx
@@ -11,7 +11,7 @@ import {
 	AlertDialogContent,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useValidateNameDescriptionAndTags } from "../hooks/use-validate-name-and-description";
 import { GhCardXmlPaste, useXmlPasteHandler } from "./gh-card-xml-paste";
 import { Button } from "@/components/ui/button";
@@ -33,6 +33,7 @@ export function AddGhDialog(props: {
 	const [addError, setAddError] = useState("");
 	const [xmlData, setXmlData] = useState<string>();
 	const [isValidXml, setIsValidXml] = useState(false);
+	const autoFilledNameRef = useRef<string | null>(null);
 	const {
 		name,
 		setName,
@@ -55,10 +56,24 @@ export function AddGhDialog(props: {
 		setAddError,
 		{
 			onSingleScriptComponent: (nickName) => {
-				if (name.length === 0 && nickName.length > 0) setName(nickName);
+				if (name.length === 0 && nickName.length > 0) {
+					setName(nickName);
+					autoFilledNameRef.current = nickName;
+				}
 			},
 		}
 	);
+
+	const handleClearPastedXml = () => {
+		if (
+			autoFilledNameRef.current !== null &&
+			name === autoFilledNameRef.current
+		) {
+			setName("");
+		}
+		autoFilledNameRef.current = null;
+		setIsValidXml(false);
+	};
 
 	const handleSubmit = async () => {
 		if (isValidXml && isValid && xmlData) {
@@ -83,6 +98,7 @@ export function AddGhDialog(props: {
 			setTags([]);
 			setName("");
 			setDescription("");
+			autoFilledNameRef.current = null;
 		}
 	};
 
@@ -103,6 +119,7 @@ export function AddGhDialog(props: {
 		setTags([]);
 		setTag("");
 		setXmlData(undefined);
+		autoFilledNameRef.current = null;
 		props.setOpen(false);
 	};
 
@@ -125,6 +142,7 @@ export function AddGhDialog(props: {
 								xmlError={addError}
 								setXmlError={setAddError}
 								handlePasteFromClipboard={handlePasteFromClipboard}
+								onClearPastedXml={handleClearPastedXml}
 							/>
 							<div className="flex flex-col gap-y-1.5">
 								<Input

--- a/src/app/components/add-gh-dialog.tsx
+++ b/src/app/components/add-gh-dialog.tsx
@@ -52,7 +52,12 @@ export function AddGhDialog(props: {
 	const { handlePasteFromClipboard } = useXmlPasteHandler(
 		setXmlData,
 		setIsValidXml,
-		setAddError
+		setAddError,
+		{
+			onSingleScriptComponent: (nickName) => {
+				if (name.length === 0 && nickName.length > 0) setName(nickName);
+			},
+		}
 	);
 
 	const handleSubmit = async () => {
@@ -128,6 +133,7 @@ export function AddGhDialog(props: {
 									placeholder="NameOfGhCardInPascalCase"
 									className="font-semibold"
 									maxLength={30}
+									value={name}
 									onChange={(e) => setName(e.target.value)}
 									disabled={props.adding}
 									autoComplete="off"

--- a/src/app/components/gh-card-xml-paste.test.ts
+++ b/src/app/components/gh-card-xml-paste.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "vitest";
+import fs from "node:fs";
+import { buildGhJson } from "parser/sand/src/parser";
+import {
+	getSingleScriptNickName,
+	sanitizeGhCardName,
+} from "./gh-card-xml-paste";
+
+test("sanitizeGhCardName strips disallowed characters", () => {
+	expect(sanitizeGhCardName("MyScript:foo")).toBe("MyScriptfoo");
+});
+
+test("sanitizeGhCardName trims whitespace and strips symbols", () => {
+	expect(sanitizeGhCardName("  C#  ")).toBe("C");
+});
+
+test("sanitizeGhCardName truncates to 30 characters", () => {
+	const longName = "A".repeat(40);
+	expect(sanitizeGhCardName(longName)).toBe("A".repeat(30));
+});
+
+test("getSingleScriptNickName returns sanitized nickName for single script component", () => {
+	const xml = fs.readFileSync("parser/sand/xmls/csharp-component.xml", "utf8");
+	const parsed = buildGhJson(xml);
+
+	expect(getSingleScriptNickName(parsed)).toBe("C");
+});
+
+test("getSingleScriptNickName returns undefined for non-script single component", () => {
+	const xml = fs.readFileSync("parser/sand/xmls/relay-single.xml", "utf8");
+	const parsed = buildGhJson(xml);
+
+	expect(getSingleScriptNickName(parsed)).toBeUndefined();
+});
+
+test("getSingleScriptNickName returns undefined for multi-component paste", () => {
+	const xml = fs.readFileSync("parser/sand/xmls/brep-area-Wire.xml", "utf8");
+	const parsed = buildGhJson(xml);
+
+	expect(getSingleScriptNickName(parsed)).toBeUndefined();
+});

--- a/src/app/components/gh-card-xml-paste.tsx
+++ b/src/app/components/gh-card-xml-paste.tsx
@@ -1,7 +1,24 @@
 import { X } from "lucide-react";
 import { useEffect } from "react";
 import posthog from "posthog-js";
+import { buildGhJson } from "parser/sand/src/parser";
+import type { ParsedGrasshopper } from "parser/sand/src/types";
 import { validateGhXml } from "../utils/gh-xml";
+
+export function sanitizeGhCardName(raw: string): string {
+	return raw.trim().replace(/[^\p{L}\p{N}]/gu, "").slice(0, 30);
+}
+
+export function getSingleScriptNickName(
+	parsed: ParsedGrasshopper
+): string | undefined {
+	const components = Object.values(parsed.components);
+	if (components.length !== 1 || !components[0]?.script) {
+		return undefined;
+	}
+	const sanitized = sanitizeGhCardName(components[0].nickName);
+	return sanitized.length > 0 ? sanitized : undefined;
+}
 
 export function GhCardXmlPaste(props: {
 	xmlData: string | undefined;
@@ -83,7 +100,8 @@ export function GhCardXmlPaste(props: {
 export function useXmlPasteHandler(
 	setXmlData: (data: string | undefined) => void,
 	setIsValidXml: (valid: boolean) => void,
-	setXmlError: (error: string) => void
+	setXmlError: (error: string) => void,
+	options?: { onSingleScriptComponent?: (nickName: string) => void }
 ) {
 	const handlePasteFromClipboard = async () => {
 		setXmlError("");
@@ -102,6 +120,15 @@ export function useXmlPasteHandler(
 			const { isValid, errorMsg } = validateGhXml(text);
 
 			if (isValid) {
+				try {
+					const parsed = buildGhJson(text);
+					const nickName = getSingleScriptNickName(parsed);
+					if (nickName) {
+						options?.onSingleScriptComponent?.(nickName);
+					}
+				} catch {
+					// Parse failure should not block a valid XML paste.
+				}
 				setIsValidXml(true);
 				setXmlData(text);
 			} else {

--- a/src/app/components/gh-card-xml-paste.tsx
+++ b/src/app/components/gh-card-xml-paste.tsx
@@ -27,6 +27,7 @@ export function GhCardXmlPaste(props: {
 	xmlError: string;
 	setXmlError: (error: string) => void;
 	handlePasteFromClipboard: () => void;
+	onClearPastedXml?: () => void;
 	isEditMode?: boolean;
 }) {
 	const { xmlData, isValidXml, setXmlError } = props;
@@ -40,6 +41,7 @@ export function GhCardXmlPaste(props: {
 	const handleClear = () => {
 		props.setXmlData(undefined);
 		props.setXmlError("");
+		props.onClearPastedXml?.();
 	};
 
 	return (


### PR DESCRIPTION
## Summary
- Auto-fills the Add Card dialog Name field when pasting a valid GhXml containing exactly one script component
- Sanitizes the component `nickName` to match `GhCardSchema` (letters/numbers only, max 30 chars) and only pre-fills when the Name field is empty
- Makes the Name input controlled so programmatic pre-fill updates the field and character counter

Closes tsoumdoa/hopperclip#88

## Test plan
- [x] `pnpm test` — sanitizer and single-script detection unit tests pass
- [x] `pnpm exec tsc --noEmit` — typecheck passes
- [ ] Paste `parser/sand/xmls/csharp-component.xml` in Add dialog → Name pre-fills with sanitized nickName (`C`)
- [ ] Paste multi-component XML → Name stays empty
- [ ] Type a name first, then paste single script XML → Name is not overwritten
- [ ] Paste non-script single component (`relay-single.xml`) → Name stays empty
- [ ] Edit-mode paste path unchanged (no callback wired in `use-gh-card-control.ts`)


Made with [Cursor](https://cursor.com)