### PR TITLE
Fix logged-in landing page flash on home route

### DIFF
--- a/src/app/components/auth-loading-screen.tsx
+++ b/src/app/components/auth-loading-screen.tsx
@@ -1,0 +1,10 @@
+import { LoadingSpinner } from "@/app/ghcards/components/loading-spinner";
+
+export function AuthLoadingScreen() {
+	return (
+		<div className="flex min-h-screen animate-in fade-in flex-col items-center justify-center bg-black font-sans text-white duration-300">
+			<h1 className="mb-6 text-2xl font-bold md:text-4xl">Hopper Clip</h1>
+			<LoadingSpinner variant="regular" />
+		</div>
+	);
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,26 +1,31 @@
 import { SignUpButton, useAuth } from "@clerk/tanstack-react-start";
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
-import { useEffect } from "react";
+import { AuthLoadingScreen } from "@/app/components/auth-loading-screen";
 import Footer from "@/app/components/footer";
 import Header from "@/app/components/header";
+import { fetchClerkAuth } from "./__root";
 
 export const Route = createFileRoute("/")({
 	head: () => ({
 		meta: [{ title: "Hopper Clip — Grasshopper script pastebin" }],
 	}),
+	beforeLoad: async () => {
+		const { userId } = await fetchClerkAuth();
+		if (userId) {
+			throw redirect({ to: "/ghcards" });
+		}
+	},
+	pendingComponent: AuthLoadingScreen,
 	component: Home,
 });
 
 function Home() {
-	const { isSignedIn, isLoaded } = useAuth();
-	const navigate = useNavigate();
+	const { isLoaded } = useAuth();
 
-	useEffect(() => {
-		if (isLoaded && isSignedIn) {
-			navigate({ to: "/ghcards", replace: true });
-		}
-	}, [isLoaded, isSignedIn, navigate]);
+	if (!isLoaded) {
+		return <AuthLoadingScreen />;
+	}
 
 	return (
 		<div className="min-h-screen bg-black font-sans text-white">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a flash where logged-in users briefly saw the full landing page (hero, CTAs, Sign in/Sign up buttons) before being redirected to `/ghcards` after the TanStack Start migration.

## Changes

- Add server-side redirect in `/` route `beforeLoad` using `fetchClerkAuth`, matching the existing `_authed` auth pattern
- Add `AuthLoadingScreen` — a full-screen animated loader shown while auth resolves
- Use `pendingComponent` during `beforeLoad` and gate landing page render on `isLoaded`
- Remove client-side `useEffect` redirect that ran after paint

## Behavior

| User state | Visiting `/` |
|---|---|
| Signed in | Redirected to `/ghcards` before landing page renders |
| Signed out | Brief loading screen, then landing page |
| Direct `/ghcards` | Unchanged (`_authed` guard still applies) |

## Testing

- [x] `pnpm run check` passes (eslint + tsc)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f177f-1665-7c5d-966e-36be684cb42e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f177f-1665-7c5d-966e-36be684cb42e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated loading screen shown while authentication is being checked.
  * Signed-in users are now sent to the main app automatically from the home route.

* **Bug Fixes**
  * Improved the home page experience by avoiding unnecessary redirect behavior during page load.
  * Kept the landing page visible only when authentication status is fully loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->