### PR TITLE
Harden post sharing and storage access

### DIFF
--- a/convex/ghCard.ts
+++ b/convex/ghCard.ts
@@ -1,7 +1,32 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import { UserTag, SortOrder } from "../src/types/types";
+import {
+	GhCardSchema,
+	ShareLinkUidSchema,
+	StorageKeySchema,
+	UserTag,
+	SortOrder,
+} from "../src/types/types";
 import { generateSharableLinkUid } from "../src/utils/generage-shareable-link-uid";
+
+const DEFAULT_SHARE_EXPIRY_HOURS = 24 * 7;
+const MAX_SHARE_EXPIRY_HOURS = 24 * 30;
+
+function validateStorageKey(uid: string) {
+	const parsed = StorageKeySchema.safeParse(uid);
+	if (!parsed.success) {
+		throw new Error("Invalid storage key");
+	}
+	return parsed.data;
+}
+
+function validateShareToken(shareToken: string) {
+	const parsed = ShareLinkUidSchema.safeParse(shareToken);
+	if (!parsed.success) {
+		throw new Error("Invalid share token");
+	}
+	return parsed.data;
+}
 
 export const addPost = mutation({
 	args: {
@@ -15,12 +40,18 @@ export const addPost = mutation({
 		if (identity === null) {
 			throw new Error("Not authenticated");
 		}
+		GhCardSchema.parse({
+			name: args.name,
+			description: args.description,
+			tags: args.tags,
+		});
+		const bucketUrl = validateStorageKey(args.uid);
 		await ctx.db.insert("post", {
 			name: args.name,
 			description: args.description,
 			tags: args.tags,
 			clerkUserId: identity.id as string,
-			bucketUrl: args.uid,
+			bucketUrl,
 			dateCreated: new Date().toISOString(),
 			dateUpdated: new Date().toISOString(),
 		});
@@ -35,6 +66,13 @@ export const deletePost = mutation({
 		const identity = await ctx.auth.getUserIdentity();
 		if (identity === null) {
 			throw new Error("Not authenticated");
+		}
+		const post = await ctx.db.get(args.id);
+		if (!post) {
+			throw new Error("Post not found");
+		}
+		if (post.clerkUserId !== identity.id) {
+			throw new Error("Not authorized to delete this post");
 		}
 		await ctx.db.delete("post", args.id);
 
@@ -62,13 +100,26 @@ export const updatePost = mutation({
 		if (identity === null) {
 			throw new Error("Not authenticated");
 		}
+		const post = await ctx.db.get(args.id);
+		if (!post) {
+			throw new Error("Post not found");
+		}
+		if (post.clerkUserId !== identity.id) {
+			throw new Error("Not authorized to update this post");
+		}
+		GhCardSchema.partial().parse({
+			name: args.name,
+			description: args.description,
+			tags: args.tags,
+		});
 		if (args.uid !== undefined && args.uid !== null) {
+			const bucketUrl = validateStorageKey(args.uid);
 			await ctx.db.patch("post", args.id, {
 				name: args.name,
 				description: args.description,
 				tags: args.tags,
 				dateUpdated: new Date().toISOString(),
-				bucketUrl: args.uid,
+				bucketUrl,
 			});
 		} else {
 			await ctx.db.patch("post", args.id, {
@@ -274,7 +325,11 @@ export const createShare = mutation({
 
 		const shareToken = generateSharableLinkUid();
 
-		const expiresInMs = (args.expiresInHours ?? 24 * 7) * 60 * 60 * 1000;
+		const expiresInHours = args.expiresInHours ?? DEFAULT_SHARE_EXPIRY_HOURS;
+		if (expiresInHours < 1 || expiresInHours > MAX_SHARE_EXPIRY_HOURS) {
+			throw new Error("Share expiry must be between 1 hour and 30 days");
+		}
+		const expiresInMs = expiresInHours * 60 * 60 * 1000;
 		const expiryDate = new Date(now.getTime() + expiresInMs);
 
 		// Create the share record
@@ -304,10 +359,11 @@ export const revokeShare = mutation({
 		if (identity === null) {
 			throw new Error("Not authenticated");
 		}
+		const shareToken = validateShareToken(args.shareToken);
 
 		const share = await ctx.db
 			.query("shares")
-			.withIndex("by_shareToken", (q) => q.eq("shareToken", args.shareToken))
+			.withIndex("by_shareToken", (q) => q.eq("shareToken", shareToken))
 			.first();
 
 		if (!share) {
@@ -333,6 +389,13 @@ export const getActiveSharesForPost = query({
 		if (identity === null) {
 			throw new Error("Not authenticated");
 		}
+		const post = await ctx.db.get(args.postId);
+		if (!post) {
+			throw new Error("Post not found");
+		}
+		if (post.clerkUserId !== identity.id) {
+			throw new Error("Not authorized to view shares for this post");
+		}
 
 		const shares = await ctx.db
 			.query("shares")
@@ -356,9 +419,10 @@ export const getSharedPost = query({
 		shareToken: v.string(),
 	},
 	handler: async (ctx, args) => {
+		const shareToken = validateShareToken(args.shareToken);
 		const share = await ctx.db
 			.query("shares")
-			.withIndex("by_shareToken", (q) => q.eq("shareToken", args.shareToken))
+			.withIndex("by_shareToken", (q) => q.eq("shareToken", shareToken))
 			.first();
 
 		if (!share) {

--- a/convex/ghInternalQuery.ts
+++ b/convex/ghInternalQuery.ts
@@ -1,25 +1,30 @@
 import { internalQuery } from "./_generated/server";
 import { v } from "convex/values";
 import { bucketUrl } from "../src/utils/utils";
+import { ShareLinkUidSchema, StorageKeySchema } from "../src/types/types";
 
 export const getShareableLink = internalQuery({
 	args: {
 		shareToken: v.string(),
 	},
 	handler: async (ctx, args) => {
+		const shareToken = ShareLinkUidSchema.safeParse(args.shareToken);
+		if (!shareToken.success) return null;
+
 		const share = await ctx.db
 			.query("shares")
-			.withIndex("by_shareToken", (q) => q.eq("shareToken", args.shareToken))
+			.withIndex("by_shareToken", (q) => q.eq("shareToken", shareToken.data))
 			.first();
 		if (!share) return null;
 		if (new Date(share.expiryDate) <= new Date()) return null;
-		const post = await ctx.db
-			.query("post")
-			.withIndex("by_id", (q) => q.eq("_id", share.postId))
-			.first();
+		const post = await ctx.db.get(share.postId);
 
 		if (!post) return null;
+		if (post.clerkUserId !== share.clerkUserId) return null;
 
-		return bucketUrl(share.clerkUserId, post.bucketUrl);
+		const storageKey = StorageKeySchema.safeParse(post.bucketUrl);
+		if (!storageKey.success) return null;
+
+		return bucketUrl(share.clerkUserId, storageKey.data);
 	},
 });

--- a/convex/ghPublicAction.ts
+++ b/convex/ghPublicAction.ts
@@ -2,6 +2,7 @@ import { internal } from "./_generated/api";
 import { action } from "./_generated/server";
 import { v } from "convex/values";
 import { AwsClient } from "aws4fetch";
+import { ShareLinkUidSchema } from "../src/types/types";
 
 const r2Client = new AwsClient({
 	accessKeyId: process.env.R2_ACCESS_KEY_ID!,
@@ -14,8 +15,9 @@ export const generateShareableLink = action({
 		shareToken: v.string(),
 	},
 	handler: async (ctx, args) => {
+		const shareToken = ShareLinkUidSchema.parse(args.shareToken);
 		const url = await ctx.runQuery(internal.ghInternalQuery.getShareableLink, {
-			shareToken: args.shareToken,
+			shareToken,
 		});
 
 		if (!url) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"convex:generate": "pnpm dlx convex dev"
 	},
 	"dependencies": {
-		"@clerk/tanstack-react-start": "^0.27.17",
+		"@clerk/tanstack-react-start": "^0.29.13",
 		"@icons-pack/react-simple-icons": "^13.13.0",
 		"@radix-ui/react-alert-dialog": "^1.1.18",
 		"@radix-ui/react-dialog": "^1.1.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@clerk/tanstack-react-start':
-        specifier: ^0.27.17
-        version: 0.27.17(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/react-start@1.168.27(crossws@0.4.8(srvx@0.11.20))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^0.29.13
+        version: 0.29.13(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/react-start@1.168.27(crossws@0.4.8(srvx@0.11.20))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@icons-pack/react-simple-icons':
         specifier: ^13.13.0
         version: 13.13.0(react@19.2.7)
@@ -64,7 +64,7 @@ importers:
         version: 2.1.1
       convex:
         specifier: ^1.42.1
-        version: 1.42.1(@clerk/clerk-react@5.61.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@clerk/react@6.7.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 1.42.1(@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@clerk/react@6.7.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       fast-xml-parser:
         specifier: ^5.9.3
         version: 5.9.3
@@ -234,10 +234,9 @@ packages:
     resolution: {integrity: sha512-YOzUYJfb1d4w+0rKKm+LnnNpkJGQ+NI/g7qmF3mgaSN9X9huteuwCZyufdsI7z2DDkwy/yGRgb9eUWV96t7xLg==}
     engines: {node: '>=18.17.0'}
 
-  '@clerk/clerk-react@5.61.3':
-    resolution: {integrity: sha512-W21aNEeHtqh3xJLuW5g2ydben/1D5pSnxsl/kCnv0IY1zma7lO+aIJ7Br2bR4FKKkiu695mPnjtY+fvkQmCXBg==}
+  '@clerk/clerk-react@5.61.8':
+    resolution: {integrity: sha512-n+k3q3xeyDkIPGTVA1J4Pd0+6MbS9Ia04qNlecOztTHwFfcirO5hy4TpOXrpGnO+GzYBuUMp7pYc3//ybMdEfg==}
     engines: {node: '>=18.17.0'}
-    deprecated: 'This package is no longer supported. Please use @clerk/react instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -273,19 +272,14 @@ packages:
       react-dom:
         optional: true
 
-  '@clerk/tanstack-react-start@0.27.17':
-    resolution: {integrity: sha512-Xmg7lan8DgiRjmbCkrc0RuO8wtCPuIIwQuLGhNORkBO74EhNBWc0dMuCJm2uK+8uLrt8dtU4H+lQ4swFmGvMXQ==}
+  '@clerk/tanstack-react-start@0.29.13':
+    resolution: {integrity: sha512-73bnpLxmRlQblhpqewxjkIVCn7/lBmwIcH4rOlhXSdVmiqXbCwNpAuUt2AMF/6bJof2w+TfEOxlEfwp6DJCFAA==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
-      '@tanstack/react-router': ^1.132.0
-      '@tanstack/react-start': ^1.132.0
+      '@tanstack/react-router': ^1.157.0
+      '@tanstack/react-start': ^1.157.0
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
-
-  '@clerk/types@4.101.20':
-    resolution: {integrity: sha512-MHvr1tGL5lwxD6zdzzixkHICbbZz/S1LChONKR52Qeu0yRGChZomPknsgqBMG9J3yNeyhaj0SWa5phQgQUk0lg==}
-    engines: {node: '>=18.17.0'}
-    deprecated: 'This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
 
   '@clerk/types@4.101.25':
     resolution: {integrity: sha512-gPxm3hlBkP7B9EfKyp3/UDonNOjg7Z0UvqfrMj5u8gA8nyzvC1UFYtSTTmTfgSY82+5Yo38YV0DYu9vNf6t9CQ==}
@@ -3603,7 +3597,7 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/clerk-react@5.61.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@clerk/shared': 3.47.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
@@ -3641,24 +3635,17 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
     optional: true
 
-  '@clerk/tanstack-react-start@0.27.17(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/react-start@1.168.27(crossws@0.4.8(srvx@0.11.20))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@clerk/tanstack-react-start@0.29.13(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/react-start@1.168.27(crossws@0.4.8(srvx@0.11.20))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@clerk/backend': 2.33.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@clerk/clerk-react': 5.61.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/clerk-react': 5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@clerk/shared': 3.47.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@clerk/types': 4.101.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/types': 4.101.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start': 1.168.27(crossws@0.4.8(srvx@0.11.20))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       tslib: 2.8.1
-
-  '@clerk/types@4.101.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@clerk/shared': 3.47.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-    transitivePeerDependencies:
-      - react
-      - react-dom
 
   '@clerk/types@4.101.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -5253,13 +5240,13 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  convex@1.42.1(@clerk/clerk-react@5.61.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@clerk/react@6.7.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  convex@1.42.1(@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@clerk/react@6.7.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
       esbuild: 0.27.0
       prettier: 3.9.4
       ws: 8.21.0
     optionalDependencies:
-      '@clerk/clerk-react': 5.61.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/clerk-react': 5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@clerk/react': 6.7.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
     transitivePeerDependencies:

--- a/src/app/hooks/use-fetch-gh-xml.ts
+++ b/src/app/hooks/use-fetch-gh-xml.ts
@@ -2,12 +2,15 @@ import { generatePresigneDownloadUrl } from "@/server/r2-storage";
 import { useMutation } from "@tanstack/react-query";
 import { useRef } from "react";
 import { decompress } from "../utils/gzip";
+import { MAX_COMPRESSED_GH_XML_BYTES } from "@/types/types";
 
 export function useFetchGhXml() {
 	const decodedRef = useRef<string | undefined>(undefined);
 	const { mutateAsync: downloadData } = useMutation({
 		mutationFn: async (bucketId: string) => {
-			const presignedUrl = await generatePresigneDownloadUrl({ data: bucketId });
+			const presignedUrl = await generatePresigneDownloadUrl({
+				data: bucketId,
+			});
 			const res = await fetch(presignedUrl, {
 				cache: "no-store",
 				headers: {
@@ -19,6 +22,9 @@ export function useFetchGhXml() {
 				throw new Error(`HTTP error! status: ${res.status}`);
 			}
 			const blob = await res.blob();
+			if (blob.size > MAX_COMPRESSED_GH_XML_BYTES) {
+				throw new Error("GhXml download is too large");
+			}
 			const uncompressed = await decompress(await blob.arrayBuffer());
 			const decoded = new TextDecoder().decode(uncompressed);
 			return decoded;

--- a/src/app/share/hooks/use-share-flow-state.ts
+++ b/src/app/share/hooks/use-share-flow-state.ts
@@ -6,6 +6,7 @@ import { buildGhJson } from "parser/src/parser";
 import { generateFlowData } from "../../duckerweb/gh-flow-generator";
 import type { GHNode } from "../../duckerweb/types/type";
 import type { Edge } from "@xyflow/react";
+import { MAX_COMPRESSED_GH_XML_BYTES } from "@/types/types";
 
 export function useShareFlowState(shareToken: string) {
 	const getPresignedUrl = useAction(api.ghPublicAction.generateShareableLink);
@@ -38,6 +39,9 @@ export function useShareFlowState(shareToken: string) {
 			}
 
 			const blob = await res.blob();
+			if (blob.size > MAX_COMPRESSED_GH_XML_BYTES) {
+				throw new Error("GhXml download is too large");
+			}
 			const uncompressed = await decompress(await blob.arrayBuffer());
 			const decoded = new TextDecoder().decode(uncompressed);
 			setDecodedXml(decoded);
@@ -47,9 +51,7 @@ export function useShareFlowState(shareToken: string) {
 			setNodes(flowData.nodes as GHNode[]);
 			setEdges(flowData.edges);
 		} catch (e) {
-			setError(
-				e instanceof Error ? e.message : "Failed to load flow data"
-			);
+			setError(e instanceof Error ? e.message : "Failed to load flow data");
 		} finally {
 			setLoading(false);
 		}

--- a/src/app/utils/gzip.ts
+++ b/src/app/utils/gzip.ts
@@ -1,15 +1,22 @@
 import pako from "pako";
+import { MAX_DECOMPRESSED_GH_XML_BYTES } from "@/types/types";
 
 export const compress = (data: string) => {
 	const gziped = pako.gzip(data);
 	return gziped as Uint8Array<ArrayBuffer>;
 };
 
-export const decompress = async (data: ArrayBuffer): Promise<Uint8Array> => {
+export const decompress = async (
+	data: ArrayBuffer,
+	maxBytes = MAX_DECOMPRESSED_GH_XML_BYTES
+): Promise<Uint8Array> => {
 	//check if it's already decompressed
 	const view = new Uint8Array(data);
 	const isGzipped = view[0] === 0x1f && view[1] === 0x8b;
 	if (!isGzipped) {
+		if (view.byteLength > maxBytes) {
+			throw new Error("GhXml is too large");
+		}
 		return view;
 	}
 
@@ -17,5 +24,8 @@ export const decompress = async (data: ArrayBuffer): Promise<Uint8Array> => {
 		new DecompressionStream("gzip")
 	);
 	const decompressed = await new Response(stream).arrayBuffer();
+	if (decompressed.byteLength > maxBytes) {
+		throw new Error("GhXml is too large");
+	}
 	return new Uint8Array(decompressed);
 };

--- a/src/app/utils/gzip.ts
+++ b/src/app/utils/gzip.ts
@@ -23,9 +23,26 @@ export const decompress = async (
 	const stream = new Response(data).body!.pipeThrough(
 		new DecompressionStream("gzip")
 	);
-	const decompressed = await new Response(stream).arrayBuffer();
-	if (decompressed.byteLength > maxBytes) {
-		throw new Error("GhXml is too large");
+	const reader = stream.getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) {
+			break;
+		}
+		total += value.byteLength;
+		if (total > maxBytes) {
+			await reader.cancel();
+			throw new Error("GhXml is too large");
+		}
+		chunks.push(value);
 	}
-	return new Uint8Array(decompressed);
+	const result = new Uint8Array(total);
+	let offset = 0;
+	for (const chunk of chunks) {
+		result.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return result;
 };

--- a/src/server/r2-storage.ts
+++ b/src/server/r2-storage.ts
@@ -3,6 +3,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import { r2Client } from "./bucket";
 import { bucketUrl } from "@/utils/utils";
+import { MAX_COMPRESSED_GH_XML_BYTES, StorageKeySchema } from "@/types/types";
 
 async function requireAuthenticatedUserId() {
 	const { isAuthenticated, userId } = await auth();
@@ -21,19 +22,17 @@ async function ensureOk(res: Response, action: string) {
 }
 
 export const uploadToBucket = createServerFn({ method: "POST" })
-	.validator(
-		(input: unknown) => {
-			const parsed = z
-				.object({
-					nanoId: z
-						.string()
-						.regex(/^[A-Za-z0-9_-]{1,}$/),
-					ghXmlZipped: z.array(z.number().int().min(0).max(255)),
-				})
-				.parse(input);
-			return parsed;
-		}
-	)
+	.validator((input: unknown) => {
+		const parsed = z
+			.object({
+				nanoId: StorageKeySchema,
+				ghXmlZipped: z
+					.array(z.number().int().min(0).max(255))
+					.max(MAX_COMPRESSED_GH_XML_BYTES),
+			})
+			.parse(input);
+		return parsed;
+	})
 	.handler(async ({ data }) => {
 		const userId = await requireAuthenticatedUserId();
 		const ghXmlZipped = new Uint8Array(data.ghXmlZipped);
@@ -52,7 +51,7 @@ export const uploadToBucket = createServerFn({ method: "POST" })
 	});
 
 export const deleteFromBucket = createServerFn({ method: "POST" })
-	.validator((nanoId: string) => nanoId)
+	.validator((nanoId: string) => StorageKeySchema.parse(nanoId))
 	.handler(async ({ data: nanoId }) => {
 		const userId = await requireAuthenticatedUserId();
 
@@ -65,7 +64,7 @@ export const deleteFromBucket = createServerFn({ method: "POST" })
 	});
 
 export const generatePresigneDownloadUrl = createServerFn({ method: "POST" })
-	.validator((nanoId: string) => nanoId)
+	.validator((nanoId: string) => StorageKeySchema.parse(nanoId))
 	.handler(async ({ data: nanoId }) => {
 		const userId = await requireAuthenticatedUserId();
 		const presigned = await r2Client.sign(
@@ -91,9 +90,7 @@ export const generatePresigneDownloadUrl = createServerFn({ method: "POST" })
 export const fetchGhcardsUser = createServerFn({ method: "GET" }).handler(
 	async () => {
 		const { userId } = await auth();
-		const user = userId
-			? await clerkClient().users.getUser(userId)
-			: null;
+		const user = userId ? await clerkClient().users.getUser(userId) : null;
 
 		return {
 			userId,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -14,6 +14,16 @@ export const GhCardSchema = z.object({
 
 export type GhCard = z.infer<typeof GhCardSchema>;
 
+export const MAX_COMPRESSED_GH_XML_BYTES = 25 * 1024 * 1024;
+export const MAX_DECOMPRESSED_GH_XML_BYTES = 100 * 1024 * 1024;
+
+const StorageKeyRegex = /^[A-Za-z0-9_-]{1,64}$/;
+export const StorageKeySchema = z.string().regex(StorageKeyRegex, {
+	message: "Invalid storage key format.",
+});
+
+export type StorageKey = z.infer<typeof StorageKeySchema>;
+
 export const GhXml = z.object({
 	Archive: z.object({
 		comments: z


### PR DESCRIPTION
## Summary
- add owner checks for post update/delete and active-share lookup mutations/queries
- validate share tokens and R2 storage keys before DB lookup, storage access, and signed URL generation
- cap compressed/decompressed GhXml sizes to reduce resource-exhaustion risk
- update Clerk TanStack Start to a patched version and refresh Clerk lock entries

## Verification
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm audit --prod
- ./node_modules/.bin/tsc --noEmit
- pnpm lint
- pnpm test -- --run
- pnpm build

Note: Vitest exits 0, but still prints the existing hanging-process warning after tests complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation and ownership checks for post, share, and download actions to prevent invalid or unauthorized access.
  * Improved share link handling so invalid tokens or mismatched records now fail safely.
  * Added size limits for uploaded and downloaded data to prevent oversized file issues.
  * Updated gzip handling to stop processing content that exceeds allowed limits.
  * Improved account-related fetching to handle missing users more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->