### PR TITLE
fix: resolve errors when deleting posts

### DIFF
--- a/convex/ghCard.ts
+++ b/convex/ghCard.ts
@@ -74,16 +74,17 @@ export const deletePost = mutation({
 		if (post.clerkUserId !== identity.id) {
 			throw new Error("Not authorized to delete this post");
 		}
-		await ctx.db.delete(args.id);
 
-		const sharedPost = await ctx.db
+		const shares = await ctx.db
 			.query("shares")
 			.withIndex("by_postId", (q) => q.eq("postId", args.id))
 			.collect();
 
-		for (const share of sharedPost) {
+		for (const share of shares) {
 			await ctx.db.delete(share._id);
 		}
+
+		await ctx.db.delete(args.id);
 	},
 });
 
@@ -391,7 +392,7 @@ export const getActiveSharesForPost = query({
 		}
 		const post = await ctx.db.get(args.postId);
 		if (!post) {
-			throw new Error("Post not found");
+			return [];
 		}
 		if (post.clerkUserId !== identity.id) {
 			throw new Error("Not authorized to view shares for this post");

--- a/src/app/components/gh-card.tsx
+++ b/src/app/components/gh-card.tsx
@@ -54,10 +54,11 @@ export default function GHCard(props: {
 		loadMetrics,
 	} = useScriptMetrics();
 
-	// Query for active shares to show "Shared" badge
-	const activeShares = useQuery(api.ghCard.getActiveSharesForPost, {
-		postId: props.cardInfo._id,
-	});
+	// Skip while deleting so Convex refetches don't race with deletePost.
+	const activeShares = useQuery(
+		api.ghCard.getActiveSharesForPost,
+		deleting || deleted ? "skip" : { postId: props.cardInfo._id }
+	);
 	const hasActiveShare = activeShares && activeShares.length > 0;
 
 	const handleShare = () => {

--- a/src/app/hooks/use-gh-card-control.ts
+++ b/src/app/hooks/use-gh-card-control.ts
@@ -54,11 +54,15 @@ export default function useGhCardControl(cardInfo: GhPost) {
 		setDeleting(true);
 		try {
 			await deletePostConvex({ id: cardInfo["_id"] });
-			await deleteFromBucket({ data: cardInfo.bucketUrl! });
 			setTag("");
 			setEditMode(false);
 			setDeleted(true);
 			toast.success(`"${cardInfo.name}" deleted`);
+			try {
+				await deleteFromBucket({ data: cardInfo.bucketUrl! });
+			} catch (error) {
+				console.error("Failed to delete storage blob (post already removed):", error);
+			}
 		} catch (error) {
 			console.error("Failed to delete post:", error);
 			toast.error("Failed to delete. Please try again.");

--- a/src/server/r2-storage.ts
+++ b/src/server/r2-storage.ts
@@ -21,6 +21,14 @@ async function ensureOk(res: Response, action: string) {
 	}
 }
 
+async function ensureDeleted(res: Response) {
+	// R2/S3 may return 404 when the object is already gone; treat that as success.
+	if (res.ok || res.status === 404) {
+		return;
+	}
+	throw new Error(`R2 delete failed: ${res.status} ${res.statusText}`);
+}
+
 export const uploadToBucket = createServerFn({ method: "POST" })
 	.validator((input: unknown) => {
 		const parsed = z
@@ -60,7 +68,7 @@ export const deleteFromBucket = createServerFn({ method: "POST" })
 				method: "DELETE",
 			})
 		);
-		await ensureOk(res, "delete");
+		await ensureDeleted(res);
 	});
 
 export const generatePresigneDownloadUrl = createServerFn({ method: "POST" })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Deleting a post could fail or surface backend errors due to a race between `deletePost` and `getActiveSharesForPost`, fragile delete ordering, and strict R2 cleanup.

When `deletePost` removed the Convex record, the card's `getActiveSharesForPost` query would refetch and throw **"Post not found"** while the component was still mounted. Shares were also deleted after the post document, which could leave orphaned share rows if share cleanup failed.

If R2 blob deletion failed (for example, object already missing), the whole delete flow reported failure even though the post record was already gone.

## Fix

1. **Convex `deletePost`**: delete share records first, then the post.
2. **`getActiveSharesForPost`**: return `[]` when the post no longer exists instead of throwing.
3. **`gh-card.tsx`**: skip the active-shares query while a delete is in progress.
4. **R2 `deleteFromBucket`**: treat HTTP 404 as success (idempotent delete).
5. **Client delete flow**: mark the post deleted after Convex succeeds; R2 cleanup is best-effort.

## Test plan

- [x] `pnpm check` (eslint + tsc)
- [x] `pnpm test run`
- [ ] Manually delete a post with an active share link — should succeed without Convex query errors
- [ ] Manually delete a post without shares — should succeed and remove from grid
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4661-bdc7-7283-ad9d-acd6ba315477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4661-bdc7-7283-ad9d-acd6ba315477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post deletion so related shared items are removed reliably before the post itself.
  * Deleting a post now completes cleanly even if its stored file is already missing.
  * The card view now avoids refresh conflicts during deletion, reducing flaky delete behavior.
  * If shared items can’t be found because a post is already gone, the app now treats that as an empty result instead of showing an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->