### PR TITLE
Fix logged-in redirect so DuckerWeb stays public and reachable

### DIFF
--- a/src/app/components/auth-loading-screen.tsx
+++ b/src/app/components/auth-loading-screen.tsx
@@ -1,0 +1,7 @@
+export function AuthLoadingScreen() {
+	return (
+		<div className="flex min-h-screen items-center justify-center bg-black">
+			<div className="h-8 w-8 animate-spin rounded-full border-2 border-neutral-600 border-t-white" />
+		</div>
+	);
+}

--- a/src/app/components/header.tsx
+++ b/src/app/components/header.tsx
@@ -28,6 +28,12 @@ export default function Header() {
 					</SignUpButton>
 				</SignedOut>
 				<SignedIn>
+					<Link
+						to="/duckerweb"
+						className="text-sm font-medium text-neutral-300 transition-colors hover:text-white"
+					>
+						DuckerWeb
+					</Link>
 					<UserButton />
 				</SignedIn>
 			</div>

--- a/src/app/duckerweb/components/DuckerwebHeader.tsx
+++ b/src/app/duckerweb/components/DuckerwebHeader.tsx
@@ -1,24 +1,42 @@
+import { SignedIn, SignedOut } from "@clerk/tanstack-react-start";
 import { Link } from "@tanstack/react-router";
 
 export function DuckerwebHeader() {
 	return (
 		<header className="mb-8 flex w-full items-center justify-between">
 			<div>
-				<Link className="text-2xl font-bold md:text-4xl" to="/">
-					Hopper Clip
-				</Link>
+				<SignedIn>
+					<Link className="text-2xl font-bold md:text-4xl" to="/ghcards">
+						Hopper Clip
+					</Link>
+				</SignedIn>
+				<SignedOut>
+					<Link className="text-2xl font-bold md:text-4xl" to="/">
+						Hopper Clip
+					</Link>
+				</SignedOut>
 				<h1 className="mt-2 text-xl font-semibold text-neutral-300">
 					DuckerWeb
 				</h1>
 			</div>
-			<a
-				href="https://github.com/mcneel/ducker"
-				target="_blank"
-				rel="noopener noreferrer"
-				className="rounded-full border border-white px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-800"
-			>
-				GitHub Repo
-			</a>
+			<div className="flex items-center gap-3">
+				<SignedIn>
+					<Link
+						to="/ghcards"
+						className="rounded-full border border-white px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-800"
+					>
+						My Cards
+					</Link>
+				</SignedIn>
+				<a
+					href="https://github.com/mcneel/ducker"
+					target="_blank"
+					rel="noopener noreferrer"
+					className="rounded-full border border-white px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral-800"
+				>
+					GitHub Repo
+				</a>
+			</div>
 		</header>
 	);
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,26 +1,31 @@
 import { SignUpButton, useAuth } from "@clerk/tanstack-react-start";
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
-import { useEffect } from "react";
+import { AuthLoadingScreen } from "@/app/components/auth-loading-screen";
 import Footer from "@/app/components/footer";
 import Header from "@/app/components/header";
+import { fetchClerkAuth } from "./__root";
 
 export const Route = createFileRoute("/")({
 	head: () => ({
 		meta: [{ title: "Hopper Clip — Grasshopper script pastebin" }],
 	}),
+	beforeLoad: async () => {
+		const { userId } = await fetchClerkAuth();
+		if (userId) {
+			throw redirect({ to: "/ghcards" });
+		}
+	},
+	pendingComponent: AuthLoadingScreen,
 	component: Home,
 });
 
 function Home() {
-	const { isSignedIn, isLoaded } = useAuth();
-	const navigate = useNavigate();
+	const { isLoaded } = useAuth();
 
-	useEffect(() => {
-		if (isLoaded && isSignedIn) {
-			navigate({ to: "/ghcards", replace: true });
-		}
-	}, [isLoaded, isSignedIn, navigate]);
+	if (!isLoaded) {
+		return <AuthLoadingScreen />;
+	}
 
 	return (
 		<div className="min-h-screen bg-black font-sans text-white">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Logged-in users could get bounced to `/ghcards` when trying to use DuckerWeb. The home route used a client-side `useEffect` to redirect authenticated users, and the DuckerWeb header linked to `/` — which triggers that redirect — instead of going directly to the card library.

## Changes

- **Scope redirect to home only:** Move the signed-in redirect on `/` from a client-side `useEffect` to a server-side `beforeLoad` check. `/duckerweb` remains a public route with no auth guard and is never redirected.
- **Add navigation from cards → DuckerWeb:** Show a **DuckerWeb** link in the authenticated header on `/ghcards`.
- **Add navigation from DuckerWeb → cards:** Show a **My Cards** link on the DuckerWeb header for signed-in users, and link the Hopper Clip logo directly to `/ghcards` when signed in (instead of routing through `/`).

## Behavior after this PR

| Route | Auth | Logged-in behavior |
|-------|------|--------------------|
| `/ghcards` | Private | Requires sign-in (unchanged) |
| `/duckerweb` | Public | Stays on DuckerWeb — no auto-redirect |
| `/` | Public | Redirects signed-in users to `/ghcards` (unchanged intent, now server-side) |

## Testing

- `pnpm run check` (eslint + tsc) passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5074-6399-7d61-92a5-53f1092bf12f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5074-6399-7d61-92a5-53f1092bf12f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

