### PR TITLE
Auto-fill card name from imported Grasshopper filename

### DIFF
--- a/src/app/components/add-gh-dialog.tsx
+++ b/src/app/components/add-gh-dialog.tsx
@@ -16,7 +16,11 @@ import { toast } from "sonner";
 import { useValidateNameDescriptionAndTags } from "../hooks/use-validate-name-and-description";
 import { useDropZone } from "../hooks/use-drop-zone";
 import { DropOverlay } from "./drop-overlay";
-import { GhCardXmlPaste, useXmlPasteHandler } from "./gh-card-xml-paste";
+import {
+	GhCardXmlPaste,
+	shouldAutoFillGhCardName,
+	useXmlPasteHandler,
+} from "./gh-card-xml-paste";
 import { Button } from "@/components/ui/button";
 import AddGhTagDisplay, { AvailableGhTagDisplay } from "./add-gh-tag-display";
 import { useMutation, useQuery } from "convex/react";
@@ -51,7 +55,13 @@ export function AddGhDialog(props: AddGhDialogProps) {
 	} = useValidateNameDescriptionAndTags(setAddError, userTags ?? []);
 
 	const autoFillName = (candidate: string) => {
-		if (currentNameRef.current.length === 0 && candidate.length > 0) {
+		if (
+			candidate.length > 0 &&
+			shouldAutoFillGhCardName(
+				currentNameRef.current,
+				autoFilledNameRef.current
+			)
+		) {
 			currentNameRef.current = candidate;
 			setName(candidate);
 			autoFilledNameRef.current = candidate;
@@ -83,8 +93,11 @@ export function AddGhDialog(props: AddGhDialogProps) {
 	useEffect(() => {
 		if (!props.open) {
 			consumedInitialFileRef.current = null;
+			currentNameRef.current = "";
+			autoFilledNameRef.current = null;
+			setName("");
 		}
-	}, [props.open]);
+	}, [props.open, setName]);
 
 	useEffect(() => {
 		if (!props.open || !props.initialFile) return;

--- a/src/app/components/add-gh-dialog.tsx
+++ b/src/app/components/add-gh-dialog.tsx
@@ -33,6 +33,7 @@ export function AddGhDialog(props: AddGhDialogProps) {
 	const [xmlData, setXmlData] = useState<string>();
 	const [isValidXml, setIsValidXml] = useState(false);
 	const autoFilledNameRef = useRef<string | null>(null);
+	const currentNameRef = useRef("");
 	const {
 		name,
 		setName,
@@ -49,17 +50,27 @@ export function AddGhDialog(props: AddGhDialogProps) {
 		availableTags,
 	} = useValidateNameDescriptionAndTags(setAddError, userTags ?? []);
 
+	const autoFillName = (candidate: string) => {
+		if (currentNameRef.current.length === 0 && candidate.length > 0) {
+			currentNameRef.current = candidate;
+			setName(candidate);
+			autoFilledNameRef.current = candidate;
+		}
+	};
+
+	const handleNameChange = (value: string) => {
+		currentNameRef.current = value;
+		autoFilledNameRef.current = null;
+		setName(value);
+	};
+
 	const {
 		handlePasteFromClipboard,
 		handleFileSelected,
 		invalidatePendingImport,
 	} = useXmlPasteHandler(setXmlData, setIsValidXml, setAddError, {
-		onSingleScriptComponent: (nickName) => {
-			if (name.length === 0 && nickName.length > 0) {
-				setName(nickName);
-				autoFilledNameRef.current = nickName;
-			}
-		},
+		onSingleScriptComponent: autoFillName,
+		onFilePicked: autoFillName,
 	});
 
 	const { isDragging, dragHandlers } = useDropZone(
@@ -94,6 +105,7 @@ export function AddGhDialog(props: AddGhDialogProps) {
 			autoFilledNameRef.current !== null &&
 			name === autoFilledNameRef.current
 		) {
+			currentNameRef.current = "";
 			setName("");
 		}
 		autoFilledNameRef.current = null;
@@ -127,6 +139,7 @@ export function AddGhDialog(props: AddGhDialogProps) {
 				setXmlData(undefined);
 				setTags([]);
 				setName("");
+				currentNameRef.current = "";
 				setDescription("");
 				autoFilledNameRef.current = null;
 				toast.success(`"${name}" added to your library`);
@@ -156,6 +169,7 @@ export function AddGhDialog(props: AddGhDialogProps) {
 	const handleCancel = () => {
 		invalidatePendingImport();
 		setName("");
+		currentNameRef.current = "";
 		setDescription("");
 		setAddError("");
 		setTags([]);
@@ -199,7 +213,7 @@ export function AddGhDialog(props: AddGhDialogProps) {
 									className="font-semibold"
 									maxLength={30}
 									value={name}
-									onChange={(e) => setName(e.target.value)}
+									onChange={(e) => handleNameChange(e.target.value)}
 									disabled={props.adding}
 									autoComplete="off"
 								/>

--- a/src/app/components/gh-card-xml-paste.test.ts
+++ b/src/app/components/gh-card-xml-paste.test.ts
@@ -6,6 +6,7 @@ import {
 	getSingleScriptNickName,
 	ingestGhXml,
 	sanitizeGhCardName,
+	shouldAutoFillGhCardName,
 } from "./gh-card-xml-paste";
 
 describe("getGhCardNameFromFileName", () => {
@@ -25,6 +26,24 @@ describe("getGhCardNameFromFileName", () => {
 		expect(getGhCardNameFromFileName(`${"A".repeat(40)}.gh`)).toBe(
 			"A".repeat(30)
 		);
+	});
+});
+
+describe("shouldAutoFillGhCardName", () => {
+	test("allows an import to fill an empty name", () => {
+		expect(shouldAutoFillGhCardName("", null)).toBe(true);
+	});
+
+	test("allows a replacement file to replace the tracked auto-filled name", () => {
+		expect(shouldAutoFillGhCardName("A", "A")).toBe(true);
+	});
+
+	test("protects a name after the user edits it", () => {
+		expect(shouldAutoFillGhCardName("Custom name", null)).toBe(false);
+	});
+
+	test("does not replace a name that differs from the tracked auto-fill", () => {
+		expect(shouldAutoFillGhCardName("Custom name", "A")).toBe(false);
 	});
 });
 

--- a/src/app/components/gh-card-xml-paste.test.ts
+++ b/src/app/components/gh-card-xml-paste.test.ts
@@ -2,10 +2,31 @@ import { describe, expect, test, vi } from "vitest";
 import fs from "node:fs";
 import { buildGhJson } from "parser/src/parser";
 import {
+	getGhCardNameFromFileName,
 	getSingleScriptNickName,
 	ingestGhXml,
 	sanitizeGhCardName,
 } from "./gh-card-xml-paste";
+
+describe("getGhCardNameFromFileName", () => {
+	test("removes the .gh extension", () => {
+		expect(getGhCardNameFromFileName("Panelizer.gh")).toBe("Panelizer");
+	});
+
+	test("removes the .ghx extension case-insensitively", () => {
+		expect(getGhCardNameFromFileName("MyFacade.GHX")).toBe("MyFacade");
+	});
+
+	test("preserves dots in the basename", () => {
+		expect(getGhCardNameFromFileName("Facade.v2.gh")).toBe("Facade.v2");
+	});
+
+	test("clips names to the input's 30-character limit", () => {
+		expect(getGhCardNameFromFileName(`${"A".repeat(40)}.gh`)).toBe(
+			"A".repeat(30)
+		);
+	});
+});
 
 test("sanitizeGhCardName strips disallowed characters", () => {
 	expect(sanitizeGhCardName("MyScript:foo")).toBe("MyScriptfoo");

--- a/src/app/components/gh-card-xml-paste.tsx
+++ b/src/app/components/gh-card-xml-paste.tsx
@@ -19,6 +19,10 @@ export function sanitizeGhCardName(raw: string): string {
 		.slice(0, 30);
 }
 
+export function getGhCardNameFromFileName(fileName: string): string {
+	return fileName.replace(/\.(?:gh|ghx)$/i, "").slice(0, 30);
+}
+
 export function getSingleScriptNickName(
 	parsed: ParsedGrasshopper
 ): string | undefined {
@@ -233,8 +237,17 @@ export function useXmlPasteHandler(
 		try {
 			const xml = await ghFileToGhXml(file);
 			if (requestId !== activeRequest.current) return;
-			const result = ingestGhXml(xml, "file", options);
+			const result = ingestGhXml(xml, "file", {
+				...options,
+				// A valid file import uses its filename; script nicknames remain the
+				// clipboard-paste fallback.
+				onSingleScriptComponent: undefined,
+			});
 			if (result.isValid) {
+				const fileName = getGhCardNameFromFileName(file.name);
+				if (fileName.length > 0) {
+					options?.onFilePicked?.(fileName);
+				}
 				setIsValidXml(true);
 				setXmlData(xml);
 			} else {

--- a/src/app/components/gh-card-xml-paste.tsx
+++ b/src/app/components/gh-card-xml-paste.tsx
@@ -23,6 +23,16 @@ export function getGhCardNameFromFileName(fileName: string): string {
 	return fileName.replace(/\.(?:gh|ghx)$/i, "").slice(0, 30);
 }
 
+export function shouldAutoFillGhCardName(
+	currentName: string,
+	autoFilledName: string | null
+): boolean {
+	return (
+		currentName.length === 0 ||
+		(autoFilledName !== null && currentName === autoFilledName)
+	);
+}
+
 export function getSingleScriptNickName(
 	parsed: ParsedGrasshopper
 ): string | undefined {

--- a/src/types/gh-card.ts
+++ b/src/types/gh-card.ts
@@ -35,4 +35,5 @@ export type IngestResult = {
 
 export type UseXmlPasteHandlerOptions = {
 	onSingleScriptComponent?: (nickName: string) => void;
+	onFilePicked?: (name: string) => void;
 };


### PR DESCRIPTION
## Summary

- derive the card name from a validated `.gh` or `.ghx` filename
- apply filename auto-fill to picker, dialog drop, and page-level drop imports
- preserve user-edited names and keep clipboard nickname auto-fill unchanged
- clip derived names to the 30-character input limit

## Testing

- `pnpm test --run` (49 tests pass)
- `pnpm check`
- `pnpm exec prettier --check src/types/gh-card.ts src/app/components/gh-card-xml-paste.tsx src/app/components/add-gh-dialog.tsx src/app/components/gh-card-xml-paste.test.ts`
- `pnpm build` compiles client/server bundles; prerender cannot complete locally because required Clerk, Convex, R2, and PostHog environment variables are unavailable

Closes #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically suggests a card name when importing a `.gh` or `.ghx` file.
  * Removes file extensions and limits suggested names to 30 characters.
  * Preserves manually entered names during XML imports.

* **Bug Fixes**
  * Improved name reset behavior when clearing, submitting, or cancelling imports.
  * Prevented empty filenames from triggering card-name updates.

* **Tests**
  * Added coverage for filename-based card-name generation, including extensions, dots, and length limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->