### PR TITLE
Auto-fill card name from imported Grasshopper file

### DIFF
--- a/src/app/components/add-gh-dialog.tsx
+++ b/src/app/components/add-gh-dialog.tsx
@@ -48,6 +48,8 @@ export function AddGhDialog(props: AddGhDialogProps) {
 		onTagValueChange,
 		availableTags,
 	} = useValidateNameDescriptionAndTags(setAddError, userTags ?? []);
+	const nameRef = useRef(name);
+	nameRef.current = name;
 
 	const {
 		handlePasteFromClipboard,
@@ -55,9 +57,17 @@ export function AddGhDialog(props: AddGhDialogProps) {
 		invalidatePendingImport,
 	} = useXmlPasteHandler(setXmlData, setIsValidXml, setAddError, {
 		onSingleScriptComponent: (nickName) => {
-			if (name.length === 0 && nickName.length > 0) {
+			if (nameRef.current.length === 0 && nickName.length > 0) {
+				nameRef.current = nickName;
 				setName(nickName);
 				autoFilledNameRef.current = nickName;
+			}
+		},
+		onFilePicked: (fileName) => {
+			if (nameRef.current.length === 0) {
+				nameRef.current = fileName;
+				setName(fileName);
+				autoFilledNameRef.current = fileName;
 			}
 		},
 	});
@@ -199,7 +209,11 @@ export function AddGhDialog(props: AddGhDialogProps) {
 									className="font-semibold"
 									maxLength={30}
 									value={name}
-									onChange={(e) => setName(e.target.value)}
+									onChange={(e) => {
+										autoFilledNameRef.current = null;
+										nameRef.current = e.target.value;
+										setName(e.target.value);
+									}}
 									disabled={props.adding}
 									autoComplete="off"
 								/>

--- a/src/app/components/gh-card-xml-paste.test.ts
+++ b/src/app/components/gh-card-xml-paste.test.ts
@@ -2,10 +2,32 @@ import { describe, expect, test, vi } from "vitest";
 import fs from "node:fs";
 import { buildGhJson } from "parser/src/parser";
 import {
+	getGhCardNameFromFileName,
 	getSingleScriptNickName,
 	ingestGhXml,
 	sanitizeGhCardName,
 } from "./gh-card-xml-paste";
+
+describe("getGhCardNameFromFileName", () => {
+	test("removes .gh and .ghx extensions", () => {
+		expect(getGhCardNameFromFileName("Panelizer.gh")).toBe("Panelizer");
+		expect(getGhCardNameFromFileName("MyFacade.GHX")).toBe("MyFacade");
+	});
+
+	test("only removes the final Grasshopper extension", () => {
+		expect(getGhCardNameFromFileName("Facade.v2.ghx")).toBe("Facade.v2");
+	});
+
+	test("truncates names to the input's 30-character limit", () => {
+		expect(getGhCardNameFromFileName(`${"A".repeat(40)}.gh`)).toBe(
+			"A".repeat(30)
+		);
+	});
+
+	test("returns undefined when the basename is empty", () => {
+		expect(getGhCardNameFromFileName(".gh")).toBeUndefined();
+	});
+});
 
 test("sanitizeGhCardName strips disallowed characters", () => {
 	expect(sanitizeGhCardName("MyScript:foo")).toBe("MyScriptfoo");

--- a/src/app/components/gh-card-xml-paste.tsx
+++ b/src/app/components/gh-card-xml-paste.tsx
@@ -19,6 +19,13 @@ export function sanitizeGhCardName(raw: string): string {
 		.slice(0, 30);
 }
 
+export function getGhCardNameFromFileName(
+	fileName: string
+): string | undefined {
+	const name = fileName.replace(/\.(?:gh|ghx)$/i, "").slice(0, 30);
+	return name.length > 0 ? name : undefined;
+}
+
 export function getSingleScriptNickName(
 	parsed: ParsedGrasshopper
 ): string | undefined {
@@ -233,8 +240,14 @@ export function useXmlPasteHandler(
 		try {
 			const xml = await ghFileToGhXml(file);
 			if (requestId !== activeRequest.current) return;
-			const result = ingestGhXml(xml, "file", options);
+			// File imports derive their card name from the filename. Script nickname
+			// auto-fill remains exclusive to clipboard imports.
+			const result = ingestGhXml(xml, "file");
 			if (result.isValid) {
+				const fileName = getGhCardNameFromFileName(file.name);
+				if (fileName) {
+					options?.onFilePicked?.(fileName);
+				}
 				setIsValidXml(true);
 				setXmlData(xml);
 			} else {

--- a/src/types/gh-card.ts
+++ b/src/types/gh-card.ts
@@ -35,4 +35,5 @@ export type IngestResult = {
 
 export type UseXmlPasteHandlerOptions = {
 	onSingleScriptComponent?: (nickName: string) => void;
+	onFilePicked?: (name: string) => void;
 };


### PR DESCRIPTION
## Summary
- derive the card name from validated `.gh`/`.ghx` filenames
- cap auto-filled names at 30 characters and preserve user-entered names
- clear auto-fill tracking when the user edits the name
- keep script nickname auto-fill unchanged for clipboard imports

## Verification
- `pnpm check`
- `pnpm test --run` (49 tests)
- `pnpm build`

Closes #103