### PR TITLE
Add native GhXml paste shortcuts

### DIFF
--- a/src/app/components/add-gh-card.tsx
+++ b/src/app/components/add-gh-card.tsx
@@ -6,13 +6,25 @@ import {
 	useGhCardsPageActions,
 	useGhCardsPageState,
 } from "@/app/ghcards/contexts/gh-cards-page-context";
+import { useNativeGhXmlPaste } from "@/app/hooks/use-native-gh-xml-paste";
 import { AddGhDialog } from "./add-gh-dialog";
 
 export default function AddGHCard() {
 	const navigate = useNavigate();
 	const [adding, setAdding] = useState(false);
-	const { addDialogOpen, pendingFile } = useGhCardsPageState();
-	const { setAddDialogOpen, consumePendingFile } = useGhCardsPageActions();
+	const { addDialogOpen, pendingFile, pendingXml, hasEditingCards } =
+		useGhCardsPageState();
+	const {
+		setAddDialogOpen,
+		openAddDialogFromPaste,
+		consumePendingFile,
+		consumePendingXml,
+	} = useGhCardsPageActions();
+
+	useNativeGhXmlPaste({
+		enabled: !addDialogOpen && !hasEditingCards,
+		onPasteText: openAddDialogFromPaste,
+	});
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
@@ -52,6 +64,8 @@ export default function AddGHCard() {
 				adding={adding}
 				initialFile={pendingFile}
 				onInitialFileConsumed={consumePendingFile}
+				initialXml={pendingXml}
+				onInitialXmlConsumed={consumePendingXml}
 			/>
 			<button
 				className="h-8 rounded-md bg-black px-3 py-1 text-sm font-bold ring-2 ring-neutral-300 transition-all hover:translate-x-0.5 hover:translate-y-0.5"

--- a/src/app/components/add-gh-dialog.tsx
+++ b/src/app/components/add-gh-dialog.tsx
@@ -32,6 +32,7 @@ import type { AddGhDialogProps } from "@/types/gh-card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { createFlowPreview } from "../duckerweb/gh-flow-generator";
 import { GhFlowView } from "./gh-flow-view";
+import { useNativeGhXmlPaste } from "../hooks/use-native-gh-xml-paste";
 
 type AddDialogTab = "details" | "flow";
 
@@ -82,11 +83,17 @@ export function AddGhDialog(props: AddGhDialogProps) {
 
 	const {
 		handlePasteFromClipboard,
+		handlePastedText,
 		handleFileSelected,
 		invalidatePendingImport,
 	} = useXmlPasteHandler(setXmlData, setIsValidXml, setAddError, {
 		onSingleScriptComponent: autoFillName,
 		onFilePicked: autoFillName,
+	});
+	useNativeGhXmlPaste({
+		enabled: props.open && !props.adding,
+		onPasteText: handlePastedText,
+		allowValidGhXmlInEditable: true,
 	});
 
 	const { isDragging, dragHandlers } = useDropZone(
@@ -95,10 +102,12 @@ export function AddGhDialog(props: AddGhDialogProps) {
 	);
 
 	const consumedInitialFileRef = useRef<File | null>(null);
+	const consumedInitialXmlRef = useRef<string | null>(null);
 
 	useEffect(() => {
 		if (!props.open) {
 			consumedInitialFileRef.current = null;
+			consumedInitialXmlRef.current = null;
 			setActiveTab("details");
 			currentNameRef.current = "";
 			autoFilledNameRef.current = null;
@@ -123,6 +132,20 @@ export function AddGhDialog(props: AddGhDialogProps) {
 		props.initialFile,
 		props.onInitialFileConsumed,
 		handleFileSelected,
+	]);
+
+	useEffect(() => {
+		if (!props.open || props.initialXml == null) return;
+		if (consumedInitialXmlRef.current === props.initialXml) return;
+
+		consumedInitialXmlRef.current = props.initialXml;
+		handlePastedText(props.initialXml);
+		props.onInitialXmlConsumed?.();
+	}, [
+		props.open,
+		props.initialXml,
+		props.onInitialXmlConsumed,
+		handlePastedText,
 	]);
 
 	const handleClearPastedXml = () => {
@@ -240,6 +263,7 @@ export function AddGhDialog(props: AddGhDialogProps) {
 									handlePasteFromClipboard={handlePasteFromClipboard}
 									handleFileSelected={handleFileSelected}
 									onClearPastedXml={handleClearPastedXml}
+									pasteShortcutEnabled
 								/>
 								<div className="flex flex-col gap-y-1.5">
 									<Input

--- a/src/app/components/gh-card-xml-paste.test.ts
+++ b/src/app/components/gh-card-xml-paste.test.ts
@@ -1,13 +1,46 @@
 import { describe, expect, test, vi } from "vitest";
 import fs from "node:fs";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
 import { buildGhJson } from "parser/src/parser";
 import {
+	GhCardXmlPaste,
 	getGhCardNameFromFileName,
 	getSingleScriptNickName,
 	ingestGhXml,
 	sanitizeGhCardName,
 	shouldAutoFillGhCardName,
 } from "./gh-card-xml-paste";
+
+const xmlPasteProps = {
+	xmlData: undefined,
+	setXmlData: vi.fn(),
+	isValidXml: false,
+	xmlError: "",
+	setXmlError: vi.fn(),
+	handlePasteFromClipboard: vi.fn(),
+	handleFileSelected: vi.fn(),
+};
+
+describe("GhCardXmlPaste shortcut hint", () => {
+	test("advertises native paste when the create dialog enables it", () => {
+		const html = renderToStaticMarkup(
+			createElement(GhCardXmlPaste, {
+				...xmlPasteProps,
+				pasteShortcutEnabled: true,
+			})
+		);
+		expect(html).toContain("Press Ctrl+V to paste, or drop a file");
+	});
+
+	test("does not advertise the shortcut in edit-card controls", () => {
+		const html = renderToStaticMarkup(
+			createElement(GhCardXmlPaste, xmlPasteProps)
+		);
+		expect(html).toContain("or drop a file");
+		expect(html).not.toContain("Ctrl+V");
+	});
+});
 
 describe("getGhCardNameFromFileName", () => {
 	test("removes the .gh extension", () => {

--- a/src/app/components/gh-card-xml-paste.tsx
+++ b/src/app/components/gh-card-xml-paste.tsx
@@ -5,6 +5,7 @@ import { buildGhJson } from "parser/src/parser";
 import type { ParsedGrasshopper } from "parser/src/types";
 import { validateGhXml } from "../utils/gh-xml";
 import { GhFileError, ghFileToGhXml } from "../utils/gh-file";
+import { useModifierKeyLabel } from "../hooks/use-modifier-key-label";
 import { cn } from "@/lib/utils";
 import type {
 	GhCardXmlPasteProps,
@@ -80,6 +81,7 @@ export function ingestGhXml(
 export function GhCardXmlPaste(props: GhCardXmlPasteProps) {
 	const { xmlData, isValidXml, setXmlError } = props;
 	const inputRef = useRef<HTMLInputElement>(null);
+	const modifier = useModifierKeyLabel();
 
 	useEffect(() => {
 		if (xmlData && isValidXml) {
@@ -167,7 +169,13 @@ export function GhCardXmlPaste(props: GhCardXmlPasteProps) {
 							<span>Browse</span>
 						</button>
 					</div>
-					<p className={hintClass}>or drop a file</p>
+					<p className={hintClass}>
+						{props.pasteShortcutEnabled ? (
+							<>Press {modifier}+V to paste, or drop a file</>
+						) : (
+							"or drop a file"
+						)}
+					</p>
 					<input
 						ref={inputRef}
 						type="file"
@@ -204,29 +212,40 @@ export function useXmlPasteHandler(
 	const invalidatePendingImport = useCallback(() => {
 		activeRequest.current += 1;
 	}, []);
-
-	const handlePasteFromClipboard = async () => {
+	const beginClipboardImport = (trigger: "button" | "shortcut") => {
 		const requestId = ++activeRequest.current;
 		setXmlError("");
 		setXmlData("");
 		setIsValidXml(false);
+		posthog.capture("user_pasted", { source: "clipboard", trigger });
+		return requestId;
+	};
+	const applyPastedText = (text: string, requestId: number) => {
+		if (requestId !== activeRequest.current) return;
+		if (text.length === 0) {
+			setXmlError("Clipboard is empty");
+			return;
+		}
+		const result = ingestGhXml(text, "clipboard", options);
+		if (result.isValid) {
+			setIsValidXml(true);
+			setXmlData(text);
+		} else {
+			setXmlError(result.errorMsg ?? "Pasted GhXml is not valid");
+		}
+	};
 
-		posthog.capture("user_pasted", { source: "clipboard" });
+	const handlePastedText = (text: string) => {
+		const requestId = beginClipboardImport("shortcut");
+		applyPastedText(text, requestId);
+	};
+
+	const handlePasteFromClipboard = async () => {
+		const requestId = beginClipboardImport("button");
 
 		try {
 			const text = await navigator.clipboard.readText();
-			if (requestId !== activeRequest.current) return;
-			if (text.length === 0) {
-				setXmlError("Clipboard is empty");
-				return;
-			}
-			const result = ingestGhXml(text, "clipboard", options);
-			if (result.isValid) {
-				setIsValidXml(true);
-				setXmlData(text);
-			} else {
-				setXmlError(result.errorMsg ?? "Pasted GhXml is not valid");
-			}
+			applyPastedText(text, requestId);
 		} catch (err) {
 			if (requestId !== activeRequest.current) return;
 			setXmlError("Failed to read clipboard contents: \n" + String(err));
@@ -281,6 +300,7 @@ export function useXmlPasteHandler(
 
 	return {
 		handlePasteFromClipboard,
+		handlePastedText,
 		handleFileSelected,
 		invalidatePendingImport,
 	};

--- a/src/app/duckerweb/components/GHDiffView.test.tsx
+++ b/src/app/duckerweb/components/GHDiffView.test.tsx
@@ -1,0 +1,11 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test, vi } from "vitest";
+import { ComparisonActions } from "./GHDiffView";
+
+test("comparison actions advertise the native paste shortcut", () => {
+	const html = renderToStaticMarkup(
+		<ComparisonActions onPaste={vi.fn()} onFileSelected={vi.fn()} />
+	);
+	expect(html).toContain("Paste changed GhXml");
+	expect(html).toContain("Ctrl+V");
+});

--- a/src/app/duckerweb/components/GHDiffView.tsx
+++ b/src/app/duckerweb/components/GHDiffView.tsx
@@ -14,6 +14,7 @@ import type {
 	GHFlowCanvasFocus,
 } from "../types/type";
 import { GHFlowCanvas } from "./GHFlowCanvas";
+import { useModifierKeyLabel } from "../../hooks/use-modifier-key-label";
 
 type GHDiffViewProps = {
 	diff: GHDiffResult | null;
@@ -55,7 +56,7 @@ const statusStyles: Record<
 	},
 };
 
-function ComparisonActions({
+export function ComparisonActions({
 	onPaste,
 	onFileSelected,
 	compact = false,
@@ -65,6 +66,7 @@ function ComparisonActions({
 	compact?: boolean;
 }) {
 	const inputRef = useRef<HTMLInputElement>(null);
+	const modifier = useModifierKeyLabel();
 	const buttonClass = cn(
 		"inline-flex items-center justify-center gap-2 rounded-lg border border-neutral-700 bg-neutral-900 font-medium text-neutral-200 transition-colors hover:border-neutral-500 hover:bg-neutral-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500",
 		compact ? "px-3 py-2 text-xs" : "px-4 py-3 text-sm"
@@ -75,6 +77,9 @@ function ComparisonActions({
 			<button type="button" onClick={onPaste} className={buttonClass}>
 				<Clipboard className="h-4 w-4 text-neutral-400" />
 				Paste changed GhXml
+				<span className="rounded border border-neutral-700 px-1 py-0.5 font-mono text-[10px] text-neutral-500">
+					{modifier}+V
+				</span>
 			</button>
 			<button
 				type="button"
@@ -113,6 +118,7 @@ export function GHDiffView({
 }: GHDiffViewProps) {
 	const [focus, setFocus] = useState<GHFlowCanvasFocus | null>(null);
 	const [filter, setFilter] = useState<DiffFilter | null>(null);
+	const modifier = useModifierKeyLabel();
 	// Remounting the canvas when a new comparison arrives re-runs fitView, so
 	// the viewport never shows a stale framing from the previous diff.
 	const canvasKey = useMemo(() => ++canvasRemountSeq, [diff]);
@@ -162,7 +168,8 @@ export function GHDiffView({
 						/>
 					</div>
 					<p className="mt-4 text-xs text-neutral-600">
-						Tip: you can also drop the changed .gh or .ghx file anywhere here.
+						Tip: press {modifier}+V to paste or drop the changed .gh or .ghx
+						file anywhere here.
 					</p>
 					{error && !comparisonRejected && (
 						<p className="mt-5 rounded-lg border border-red-900/60 bg-red-950/40 px-4 py-3 text-left text-sm font-medium text-red-300">

--- a/src/app/duckerweb/components/XmlPasteArea.test.tsx
+++ b/src/app/duckerweb/components/XmlPasteArea.test.tsx
@@ -21,6 +21,7 @@ describe("XmlPasteArea", () => {
 
 		expect(html).toContain("Import a Grasshopper definition");
 		expect(html).toContain("Paste GhXml from clipboard");
+		expect(html).toContain("Press Ctrl+V to paste GhXml");
 		expect(html).toContain("Browse .gh or .ghx file");
 		expect(html).toContain("drag and drop anywhere in this view");
 		expect(html).not.toContain("Paste new GhXml");
@@ -56,6 +57,7 @@ describe("XmlPasteArea", () => {
 
 		expect(html).toContain("GhXml validated");
 		expect(html).toContain("Paste new");
+		expect(html).toContain("Ctrl+V");
 		expect(html).toContain("Browse new");
 		expect(html).toContain("Clear");
 		expect(html).not.toContain("Paste new GhXml</span>");

--- a/src/app/duckerweb/components/XmlPasteArea.tsx
+++ b/src/app/duckerweb/components/XmlPasteArea.tsx
@@ -2,6 +2,7 @@ import { Clipboard, FileUp, X } from "lucide-react";
 import { useRef } from "react";
 import { cn } from "@/lib/utils";
 import type { XmlPasteAreaProps } from "../types/type";
+import { useModifierKeyLabel } from "../../hooks/use-modifier-key-label";
 
 const actionButtonClass =
 	"flex w-full items-center justify-center gap-2.5 rounded-lg border border-neutral-700 bg-neutral-900 px-4 py-3 text-sm font-medium text-neutral-200 transition-colors hover:border-neutral-500 hover:bg-neutral-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 focus-visible:ring-offset-2 focus-visible:ring-offset-black";
@@ -18,6 +19,7 @@ export function XmlPasteArea({
 }: XmlPasteAreaProps) {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const hasLoadedDefinition = Boolean(xmlData && isValidXml);
+	const modifier = useModifierKeyLabel();
 
 	const handlePickerChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		const files = event.target.files;
@@ -59,6 +61,9 @@ export function XmlPasteArea({
 					>
 						<Clipboard className="h-3.5 w-3.5 text-neutral-400" />
 						Paste new
+						<span className="rounded border border-neutral-700 px-1 py-0.5 font-mono text-[10px] text-neutral-500">
+							{modifier}+V
+						</span>
 					</button>
 					<button
 						type="button"
@@ -108,8 +113,8 @@ export function XmlPasteArea({
 					</div>
 				) : (
 					<p className="mb-4 text-sm leading-relaxed text-neutral-400">
-						Import a Grasshopper definition to inspect its components. Paste
-						GhXml from your clipboard, browse for a{" "}
+						Import a Grasshopper definition to inspect its components. Press{" "}
+						{modifier}+V to paste GhXml, browse for a{" "}
 						<span className="font-mono text-neutral-300">.gh</span> or{" "}
 						<span className="font-mono text-neutral-300">.ghx</span> file, or
 						drag and drop anywhere in this view.
@@ -148,11 +153,10 @@ export function XmlPasteArea({
 					/>
 				</div>
 
-				{!hasLoadedDefinition && (
-					<p className="mt-3 text-center text-xs text-neutral-500">
-						Drag a file over this page to drop it anywhere in the view
-					</p>
-				)}
+				<p className="mt-3 text-center text-xs text-neutral-500">
+					Press {modifier}+V to {hasLoadedDefinition ? "replace" : "paste"}, or
+					drag a file over this page to drop it anywhere in the view
+				</p>
 			</div>
 
 			{xmlError.length > 0 && (

--- a/src/app/duckerweb/hooks/use-duckerweb-state.test.ts
+++ b/src/app/duckerweb/hooks/use-duckerweb-state.test.ts
@@ -1,6 +1,22 @@
 import fs from "node:fs";
 import { describe, expect, test } from "vitest";
-import { prepareDuckerwebImport } from "./use-duckerweb-state";
+import {
+	prepareDuckerwebImport,
+	resolveDuckerwebPasteTarget,
+} from "./use-duckerweb-state";
+
+describe("resolveDuckerwebPasteTarget", () => {
+	test("routes Diff pastes to the comparison definition", () => {
+		expect(resolveDuckerwebPasteTarget("diff")).toBe("comparison");
+	});
+
+	test.each(["list", "flow", "json"] as const)(
+		"routes %s pastes to the original definition",
+		(viewMode) => {
+			expect(resolveDuckerwebPasteTarget(viewMode)).toBe("original");
+		}
+	);
+});
 
 describe("prepareDuckerwebImport", () => {
 	test("prepares parsed data and flow state for a valid definition", () => {

--- a/src/app/duckerweb/hooks/use-duckerweb-state.test.ts
+++ b/src/app/duckerweb/hooks/use-duckerweb-state.test.ts
@@ -2,8 +2,22 @@ import fs from "node:fs";
 import { describe, expect, test } from "vitest";
 import {
 	prepareDuckerwebImport,
+	resolveDuckerwebImportView,
 	resolveDuckerwebPasteTarget,
 } from "./use-duckerweb-state";
+
+describe("resolveDuckerwebImportView", () => {
+	test.each(["list", "flow", "json"] as const)(
+		"opens Flow after a successful clipboard paste from %s",
+		(currentView) => {
+			expect(resolveDuckerwebImportView(currentView, "clipboard")).toBe("flow");
+		}
+	);
+
+	test("preserves the current view for file imports", () => {
+		expect(resolveDuckerwebImportView("list", "file")).toBe("list");
+	});
+});
 
 describe("resolveDuckerwebPasteTarget", () => {
 	test("routes Diff pastes to the comparison definition", () => {

--- a/src/app/duckerweb/hooks/use-duckerweb-state.ts
+++ b/src/app/duckerweb/hooks/use-duckerweb-state.ts
@@ -45,10 +45,18 @@ export function prepareDuckerwebImport(
 	}
 }
 
+export function resolveDuckerwebPasteTarget(
+	viewMode: ViewMode
+): "original" | "comparison" {
+	return viewMode === "diff" ? "comparison" : "original";
+}
+
 export function useDuckerwebState(): DuckerwebState & {
 	handlePasteFromClipboard: () => Promise<void>;
+	handlePastedXml: (text: string) => void;
 	handleFileSelected: (file: File) => Promise<void>;
 	handlePasteComparison: () => Promise<void>;
+	handlePastedComparisonXml: (text: string) => void;
 	handleComparisonFileSelected: (file: File) => Promise<void>;
 	handleClearComparison: () => void;
 	handleClear: () => void;
@@ -154,6 +162,26 @@ export function useDuckerwebState(): DuckerwebState & {
 		},
 		[parsedData]
 	);
+	const applyPastedXml = useCallback(
+		(text: string, requestId: number) => {
+			if (requestId !== activeRequest.current) return;
+			if (text.length === 0) {
+				setXmlError("Clipboard is empty");
+				return;
+			}
+			ingestXml(text, "clipboard");
+		},
+		[ingestXml]
+	);
+	const handlePastedXml = useCallback(
+		(text: string) => {
+			const requestId = ++activeRequest.current;
+			setXmlError("");
+			setError("");
+			applyPastedXml(text, requestId);
+		},
+		[applyPastedXml]
+	);
 
 	const handlePasteFromClipboard = useCallback(async () => {
 		const requestId = ++activeRequest.current;
@@ -162,17 +190,12 @@ export function useDuckerwebState(): DuckerwebState & {
 
 		try {
 			const text = await navigator.clipboard.readText();
-			if (requestId !== activeRequest.current) return;
-			if (text.length === 0) {
-				setXmlError("Clipboard is empty");
-				return;
-			}
-			ingestXml(text, "clipboard");
+			applyPastedXml(text, requestId);
 		} catch (err) {
 			if (requestId !== activeRequest.current) return;
 			setXmlError("Failed to read clipboard contents: \n" + String(err));
 		}
-	}, [ingestXml]);
+	}, [applyPastedXml]);
 
 	const handleFileSelected = useCallback(
 		async (file: File) => {
@@ -204,6 +227,26 @@ export function useDuckerwebState(): DuckerwebState & {
 		activeComparisonRequest.current += 1;
 		resetFlowState();
 	}, [resetFlowState]);
+	const applyPastedComparisonXml = useCallback(
+		(text: string, requestId: number) => {
+			if (requestId !== activeComparisonRequest.current) return;
+			if (text.length === 0) {
+				setDiffError("Clipboard is empty");
+				return;
+			}
+			ingestComparisonXml(text, "clipboard");
+		},
+		[ingestComparisonXml]
+	);
+	const handlePastedComparisonXml = useCallback(
+		(text: string) => {
+			const requestId = ++activeComparisonRequest.current;
+			setDiffError("");
+			setComparisonRejected(false);
+			applyPastedComparisonXml(text, requestId);
+		},
+		[applyPastedComparisonXml]
+	);
 
 	const handlePasteComparison = useCallback(async () => {
 		const requestId = ++activeComparisonRequest.current;
@@ -212,17 +255,12 @@ export function useDuckerwebState(): DuckerwebState & {
 
 		try {
 			const text = await navigator.clipboard.readText();
-			if (requestId !== activeComparisonRequest.current) return;
-			if (text.length === 0) {
-				setDiffError("Clipboard is empty");
-				return;
-			}
-			ingestComparisonXml(text, "clipboard");
+			applyPastedComparisonXml(text, requestId);
 		} catch (err) {
 			if (requestId !== activeComparisonRequest.current) return;
 			setDiffError("Failed to read clipboard contents: \n" + String(err));
 		}
-	}, [ingestComparisonXml]);
+	}, [applyPastedComparisonXml]);
 
 	const handleComparisonFileSelected = useCallback(
 		async (file: File) => {
@@ -272,8 +310,10 @@ export function useDuckerwebState(): DuckerwebState & {
 		comparisonFileName,
 		comparisonRejected,
 		handlePasteFromClipboard,
+		handlePastedXml,
 		handleFileSelected,
 		handlePasteComparison,
+		handlePastedComparisonXml,
 		handleComparisonFileSelected,
 		handleClearComparison,
 		handleClear,

--- a/src/app/duckerweb/hooks/use-duckerweb-state.ts
+++ b/src/app/duckerweb/hooks/use-duckerweb-state.ts
@@ -51,6 +51,13 @@ export function resolveDuckerwebPasteTarget(
 	return viewMode === "diff" ? "comparison" : "original";
 }
 
+export function resolveDuckerwebImportView(
+	currentView: ViewMode,
+	source: "clipboard" | "file"
+): ViewMode {
+	return source === "clipboard" ? "flow" : currentView;
+}
+
 export function useDuckerwebState(): DuckerwebState & {
 	handlePasteFromClipboard: () => Promise<void>;
 	handlePastedXml: (text: string) => void;
@@ -119,6 +126,9 @@ export function useDuckerwebState(): DuckerwebState & {
 			setParsedData(result.parsedData);
 			setNodes(result.nodes);
 			setEdges(result.edges);
+			setViewMode((currentView) =>
+				resolveDuckerwebImportView(currentView, source)
+			);
 			setXmlError("");
 			setError("");
 			setComparisonData(null);

--- a/src/app/duckerweb/page.tsx
+++ b/src/app/duckerweb/page.tsx
@@ -12,6 +12,9 @@ import { GHJsonView } from "./components/GHJsonView";
 import { GHDiffView } from "./components/GHDiffView";
 import type { ViewMode } from "./types/type";
 import { cn } from "@/lib/utils";
+import { useCallback } from "react";
+import { useNativeGhXmlPaste } from "../hooks/use-native-gh-xml-paste";
+import { resolveDuckerwebPasteTarget } from "./hooks/use-duckerweb-state";
 
 const contentWidth =
 	"mx-auto w-full max-w-6xl min-[2200px]:max-w-[140rem] 2xl:max-w-[100rem]";
@@ -43,8 +46,10 @@ export default function DuckerWebPage() {
 		comparisonFileName,
 		comparisonRejected,
 		handlePasteFromClipboard,
+		handlePastedXml,
 		handleFileSelected,
 		handlePasteComparison,
+		handlePastedComparisonXml,
 		handleComparisonFileSelected,
 		handleClearComparison,
 		handleClear,
@@ -55,6 +60,18 @@ export default function DuckerWebPage() {
 
 	const isDiff = viewMode === "diff";
 	const layout = viewLayouts[viewMode];
+	const nativePasteTarget = resolveDuckerwebPasteTarget(viewMode);
+	const handleNativePaste = useCallback(
+		(text: string) => {
+			if (nativePasteTarget === "comparison") {
+				handlePastedComparisonXml(text);
+			} else {
+				handlePastedXml(text);
+			}
+		},
+		[nativePasteTarget, handlePastedComparisonXml, handlePastedXml]
+	);
+	useNativeGhXmlPaste({ enabled: true, onPasteText: handleNativePaste });
 
 	const views: Record<ViewMode, React.ReactNode> = {
 		flow: <GHFlowCanvas nodes={nodes} edges={edges} />,

--- a/src/app/ghcards/components/shortcut-hint.test.tsx
+++ b/src/app/ghcards/components/shortcut-hint.test.tsx
@@ -1,0 +1,11 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import { ShortcutHint } from "./shortcut-hint";
+
+test("shows filter, add, and native paste shortcuts", () => {
+	const html = renderToStaticMarkup(<ShortcutHint />);
+	expect(html).toContain("Filter");
+	expect(html).toContain("Add");
+	expect(html).toContain("Paste");
+	expect(html).toContain(">V</kbd>");
+});

--- a/src/app/ghcards/components/shortcut-hint.tsx
+++ b/src/app/ghcards/components/shortcut-hint.tsx
@@ -1,15 +1,8 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useModifierKeyLabel } from "@/app/hooks/use-modifier-key-label";
 
 export function ShortcutHint() {
-	const [isMac, setIsMac] = useState(false);
-	useEffect(() => {
-		if (typeof window !== "undefined") {
-			setIsMac(window.navigator.userAgent.includes("Mac"));
-		}
-	}, []);
-
-	const mod = isMac ? "⌘" : "Ctrl";
+	const mod = useModifierKeyLabel();
 	return (
 		<div className="fixed right-4 bottom-4 hidden items-center gap-2 rounded-lg border border-neutral-700/50 bg-neutral-900/80 px-3 py-2 text-xs text-neutral-500 shadow-lg backdrop-blur-sm sm:flex">
 			<span className="flex items-center gap-1.5">
@@ -37,6 +30,18 @@ export function ShortcutHint() {
 					</kbd>
 				</span>
 				<span>Add</span>
+			</span>
+			<span className="text-neutral-700">|</span>
+			<span className="flex items-center gap-1.5">
+				<span className="flex items-center gap-0.5">
+					<kbd className="pointer-events-none inline-flex h-5 items-center rounded border border-neutral-600 bg-neutral-800 px-1.5 font-mono text-[11px] font-medium text-neutral-300 select-none">
+						{mod}
+					</kbd>
+					<kbd className="pointer-events-none inline-flex h-5 items-center rounded border border-neutral-600 bg-neutral-800 px-1.5 font-mono text-[11px] font-medium text-neutral-300 select-none">
+						V
+					</kbd>
+				</span>
+				<span>Paste</span>
 			</span>
 		</div>
 	);

--- a/src/app/ghcards/contexts/gh-cards-page-context.test.ts
+++ b/src/app/ghcards/contexts/gh-cards-page-context.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import {
+	pendingGhCardFileImport,
+	pendingGhCardXmlImport,
+} from "./gh-cards-page-context";
+
+describe("pending GH card imports", () => {
+	test("a pending file clears pending XML", () => {
+		const file = { name: "definition.gh" } as File;
+		expect(pendingGhCardFileImport(file)).toEqual({
+			pendingFile: file,
+			pendingXml: null,
+		});
+	});
+
+	test("pending XML clears the pending file", () => {
+		expect(pendingGhCardXmlImport("<Archive />")).toEqual({
+			pendingFile: null,
+			pendingXml: "<Archive />",
+		});
+	});
+});

--- a/src/app/ghcards/contexts/gh-cards-page-context.tsx
+++ b/src/app/ghcards/contexts/gh-cards-page-context.tsx
@@ -12,16 +12,32 @@ import {
 } from "react";
 import { updateEditingCardIds } from "@/app/utils/gh-card-edit-state";
 
+export type PendingGhCardImportState = {
+	pendingFile: File | null;
+	pendingXml: string | null;
+};
+
+export function pendingGhCardFileImport(file?: File): PendingGhCardImportState {
+	return { pendingFile: file ?? null, pendingXml: null };
+}
+
+export function pendingGhCardXmlImport(xml: string): PendingGhCardImportState {
+	return { pendingFile: null, pendingXml: xml };
+}
+
 type GhCardsPageState = {
 	addDialogOpen: boolean;
 	pendingFile: File | null;
+	pendingXml: string | null;
 	hasEditingCards: boolean;
 };
 
 type GhCardsPageActions = {
 	setAddDialogOpen: Dispatch<SetStateAction<boolean>>;
 	openAddDialog: (file?: File) => void;
+	openAddDialogFromPaste: (xml: string) => void;
 	consumePendingFile: () => void;
+	consumePendingXml: () => void;
 	setCardEditing: (cardId: string, editMode: boolean) => void;
 };
 
@@ -33,17 +49,29 @@ const GhCardsPageActionsContext = createContext<GhCardsPageActions | null>(
 export function GhCardsPageProvider({ children }: { children: ReactNode }) {
 	const [addDialogOpen, setAddDialogOpen] = useState(false);
 	const [pendingFile, setPendingFile] = useState<File | null>(null);
+	const [pendingXml, setPendingXml] = useState<string | null>(null);
 	const [editingCardIds, setEditingCardIds] = useState<Set<string>>(
 		() => new Set()
 	);
 
 	const openAddDialog = useCallback((file?: File) => {
-		setPendingFile(file ?? null);
+		const pending = pendingGhCardFileImport(file);
+		setPendingFile(pending.pendingFile);
+		setPendingXml(pending.pendingXml);
+		setAddDialogOpen(true);
+	}, []);
+	const openAddDialogFromPaste = useCallback((xml: string) => {
+		const pending = pendingGhCardXmlImport(xml);
+		setPendingFile(pending.pendingFile);
+		setPendingXml(pending.pendingXml);
 		setAddDialogOpen(true);
 	}, []);
 
 	const consumePendingFile = useCallback(() => {
 		setPendingFile(null);
+	}, []);
+	const consumePendingXml = useCallback(() => {
+		setPendingXml(null);
 	}, []);
 
 	const setCardEditing = useCallback((cardId: string, editMode: boolean) => {
@@ -56,18 +84,27 @@ export function GhCardsPageProvider({ children }: { children: ReactNode }) {
 		() => ({
 			addDialogOpen,
 			pendingFile,
+			pendingXml,
 			hasEditingCards: editingCardIds.size > 0,
 		}),
-		[addDialogOpen, pendingFile, editingCardIds]
+		[addDialogOpen, pendingFile, pendingXml, editingCardIds]
 	);
 	const actions = useMemo(
 		() => ({
 			setAddDialogOpen,
 			openAddDialog,
+			openAddDialogFromPaste,
 			consumePendingFile,
+			consumePendingXml,
 			setCardEditing,
 		}),
-		[openAddDialog, consumePendingFile, setCardEditing]
+		[
+			openAddDialog,
+			openAddDialogFromPaste,
+			consumePendingFile,
+			consumePendingXml,
+			setCardEditing,
+		]
 	);
 
 	return (

--- a/src/app/hooks/use-modifier-key-label.ts
+++ b/src/app/hooks/use-modifier-key-label.ts
@@ -1,0 +1,11 @@
+import { useEffect, useState } from "react";
+
+export function useModifierKeyLabel(): "⌘" | "Ctrl" {
+	const [modifier, setModifier] = useState<"⌘" | "Ctrl">("Ctrl");
+
+	useEffect(() => {
+		setModifier(window.navigator.userAgent.includes("Mac") ? "⌘" : "Ctrl");
+	}, []);
+
+	return modifier;
+}

--- a/src/app/hooks/use-native-gh-xml-paste.test.ts
+++ b/src/app/hooks/use-native-gh-xml-paste.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import { describe, expect, test } from "vitest";
+import { shouldConsumeNativeGhXmlPaste } from "./use-native-gh-xml-paste";
+
+const validGhXml = fs.readFileSync(
+	"parser/sand/xmls/csharp-component.xml",
+	"utf8"
+);
+
+describe("shouldConsumeNativeGhXmlPaste", () => {
+	test("does not consume paste while disabled", () => {
+		expect(
+			shouldConsumeNativeGhXmlPaste({
+				enabled: false,
+				text: validGhXml,
+				editableTarget: false,
+			})
+		).toBe(false);
+	});
+
+	test("consumes non-editable paste so invalid content can show feedback", () => {
+		expect(
+			shouldConsumeNativeGhXmlPaste({
+				enabled: true,
+				text: "not GhXml",
+				editableTarget: false,
+			})
+		).toBe(true);
+	});
+
+	test("preserves ordinary text paste in editable fields", () => {
+		expect(
+			shouldConsumeNativeGhXmlPaste({
+				enabled: true,
+				text: "ordinary field text",
+				editableTarget: true,
+				allowValidGhXmlInEditable: true,
+			})
+		).toBe(false);
+	});
+
+	test("consumes valid GhXml in editable fields when smart detection is enabled", () => {
+		expect(
+			shouldConsumeNativeGhXmlPaste({
+				enabled: true,
+				text: validGhXml,
+				editableTarget: true,
+				allowValidGhXmlInEditable: true,
+			})
+		).toBe(true);
+	});
+
+	test("keeps page-level editable pastes native even when they contain GhXml", () => {
+		expect(
+			shouldConsumeNativeGhXmlPaste({
+				enabled: true,
+				text: validGhXml,
+				editableTarget: true,
+			})
+		).toBe(false);
+	});
+});

--- a/src/app/hooks/use-native-gh-xml-paste.ts
+++ b/src/app/hooks/use-native-gh-xml-paste.ts
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+import { validateGhXml } from "../utils/gh-xml";
+
+type NativeGhXmlPasteDecision = {
+	enabled: boolean;
+	text: string;
+	editableTarget: boolean;
+	allowValidGhXmlInEditable?: boolean;
+};
+
+type UseNativeGhXmlPasteOptions = {
+	enabled: boolean;
+	onPasteText: (text: string) => void;
+	allowValidGhXmlInEditable?: boolean;
+};
+
+export function shouldConsumeNativeGhXmlPaste({
+	enabled,
+	text,
+	editableTarget,
+	allowValidGhXmlInEditable = false,
+}: NativeGhXmlPasteDecision): boolean {
+	if (!enabled) return false;
+	if (!editableTarget) return true;
+	return allowValidGhXmlInEditable && validateGhXml(text).isValid;
+}
+
+function isEditablePasteTarget(target: EventTarget | null): boolean {
+	return target instanceof HTMLElement
+		? target.matches("input, textarea, select") || target.isContentEditable
+		: false;
+}
+
+/**
+ * Consumes an explicit browser paste gesture without requesting programmatic
+ * clipboard access. Editable fields keep their native paste behavior unless
+ * the caller opts into importing valid GhXml from them.
+ */
+export function useNativeGhXmlPaste({
+	enabled,
+	onPasteText,
+	allowValidGhXmlInEditable = false,
+}: UseNativeGhXmlPasteOptions) {
+	useEffect(() => {
+		if (!enabled) return;
+
+		const handlePaste = (event: ClipboardEvent) => {
+			if (!event.clipboardData) return;
+
+			const text = event.clipboardData.getData("text/plain");
+			const shouldConsume = shouldConsumeNativeGhXmlPaste({
+				enabled,
+				text,
+				editableTarget: isEditablePasteTarget(event.target),
+				allowValidGhXmlInEditable,
+			});
+
+			if (!shouldConsume) return;
+			event.preventDefault();
+			onPasteText(text);
+		};
+
+		window.addEventListener("paste", handlePaste);
+		return () => window.removeEventListener("paste", handlePaste);
+	}, [allowValidGhXmlInEditable, enabled, onPasteText]);
+}

--- a/src/types/gh-card.ts
+++ b/src/types/gh-card.ts
@@ -7,6 +7,8 @@ export type AddGhDialogProps = {
 	setAdding: (adding: boolean) => void;
 	initialFile?: File | null;
 	onInitialFileConsumed?: () => void;
+	initialXml?: string | null;
+	onInitialXmlConsumed?: () => void;
 };
 
 export type GhPageFileDropLayerProps = {
@@ -25,6 +27,7 @@ export type GhCardXmlPasteProps = {
 	handleFileSelected: (file: File) => void;
 	onClearPastedXml?: () => void;
 	isEditMode?: boolean;
+	pasteShortcutEnabled?: boolean;
 };
 
 export type IngestResult = {


### PR DESCRIPTION
## Summary
- add native Cmd/Ctrl+V GhXml importing without programmatic clipboard permission prompts
- open and populate the create-card dialog from the `/ghcards` page while preserving normal field pastes
- route `/duckerweb` pastes to the original definition or the changed comparison when Diff is active
- open successful original-definition paste imports in Ducker Flow view by default
- add platform-aware shortcut hints and distinguish button versus shortcut analytics

## Focus and validation behavior
- valid GhXml can be imported while a create-card text field is focused
- ordinary text continues to paste normally into editable fields
- invalid background pastes use the existing validation feedback
- page-level GH card paste is disabled while the dialog is open or a card is being edited

## Verification
- `pnpm test --run` — 96 tests passed
- `pnpm check`
- `pnpm format:check`
- `pnpm build`
- live local `/duckerweb` render confirmed the updated Ctrl+V import guidance
