### PR TITLE
Inspect expressions with hover and click-to-pin popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.3",
 		"eslint": "^9.39.4",
+		"happy-dom": "^20.10.6",
 		"nitro": "3.0.260311-beta",
 		"prettier": "^3.6.2",
 		"prettier-plugin-tailwindcss": "^0.6.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
+      happy-dom:
+        specifier: ^20.10.6
+        version: 20.10.6
       nitro:
         specifier: 3.0.260311-beta
         version: 3.0.260311-beta(@libsql/client@0.15.15)(@vercel/functions@2.2.13)(aws4fetch@1.0.20)(chokidar@5.0.0)(jiti@2.7.0)(lru-cache@11.5.1)(rollup@4.62.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))
@@ -155,7 +158,7 @@ importers:
         version: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 3.2.6(@types/node@24.13.2)(happy-dom@20.10.6)(jiti@2.7.0)(lightningcss@1.32.0)
 
 packages:
 
@@ -1753,6 +1756,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1963,6 +1969,10 @@ packages:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
 
   bun-types@1.3.14:
     resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
@@ -2193,6 +2203,10 @@ packages:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   env-runner@0.1.15:
     resolution: {integrity: sha512-Xiu7VUW1jlwEiZSGWJ5Wuv9D4iSC2JwIB3Bb/RI+1DBSCeCrCpdAwRvsi3e52wETPUBkV61b0Ixfi593hQmQ6w==}
     hasBin: true
@@ -2403,6 +2417,10 @@ packages:
     peerDependenciesMeta:
       crossws:
         optional: true
+
+  happy-dom@20.10.6:
+    resolution: {integrity: sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -3416,6 +3434,10 @@ packages:
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4929,10 +4951,11 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 24.13.2
-    optional: true
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -5181,6 +5204,10 @@ snapshots:
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 24.13.2
+
   bun-types@1.3.14:
     dependencies:
       '@types/node': 24.13.2
@@ -5347,6 +5374,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@7.0.1: {}
 
   env-runner@0.1.15:
     dependencies:
@@ -5597,6 +5626,19 @@ snapshots:
       srvx: 0.11.20
     optionalDependencies:
       crossws: 0.4.8(srvx@0.11.20)
+
+  happy-dom@20.10.6:
+    dependencies:
+      '@types/node': 24.13.2
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -6404,7 +6446,7 @@ snapshots:
     optionalDependencies:
       vite: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
 
-  vitest@3.2.6(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0):
+  vitest@3.2.6(@types/node@24.13.2)(happy-dom@20.10.6)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -6431,6 +6473,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.2
+      happy-dom: 20.10.6
     transitivePeerDependencies:
       - jiti
       - less
@@ -6451,6 +6494,8 @@ snapshots:
   web-vitals@5.3.0: {}
 
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:

--- a/src/app/duckerweb/components/ExpressionInspector.test.tsx
+++ b/src/app/duckerweb/components/ExpressionInspector.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ExpressionInspector } from "./ExpressionInspector";
+import { EXPRESSION_HOVER_DELAY_MS } from "./expression-popup-state";
+
+(
+	globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ExpressionInspector", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeEach(() => {
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+		document
+			.querySelectorAll("[data-expression-popup]")
+			.forEach((node) => node.remove());
+		vi.useRealTimers();
+	});
+
+	function renderInspector(expression = "x / 2 + 1") {
+		act(() => {
+			root.render(<ExpressionInspector expression={expression} />);
+		});
+	}
+
+	test("shows the formula in a popup after hover delay", () => {
+		vi.useFakeTimers();
+		renderInspector();
+
+		const trigger = container.querySelector(
+			"[data-expression-trigger]"
+		) as HTMLButtonElement;
+		expect(trigger).toBeTruthy();
+
+		act(() => {
+			trigger.focus();
+		});
+		act(() => {
+			vi.advanceTimersByTime(EXPRESSION_HOVER_DELAY_MS);
+		});
+
+		const formula = document.querySelector("[data-expression-formula]");
+		expect(formula?.textContent).toBe("x / 2 + 1");
+	});
+
+	test("click pins the popup so hover-out does not dismiss it", () => {
+		vi.useFakeTimers();
+		renderInspector();
+
+		const trigger = container.querySelector(
+			"[data-expression-trigger]"
+		) as HTMLButtonElement;
+
+		act(() => {
+			trigger.click();
+		});
+
+		expect(
+			document.querySelector("[data-expression-formula]")?.textContent
+		).toBe("x / 2 + 1");
+
+		act(() => {
+			trigger.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
+			vi.advanceTimersByTime(200);
+		});
+
+		expect(
+			document.querySelector("[data-expression-formula]")?.textContent
+		).toBe("x / 2 + 1");
+	});
+
+	test("outside click unpins the expression popup", () => {
+		renderInspector();
+
+		const trigger = container.querySelector(
+			"[data-expression-trigger]"
+		) as HTMLButtonElement;
+
+		act(() => {
+			trigger.click();
+		});
+		expect(document.querySelector("[data-expression-formula]")).toBeTruthy();
+
+		act(() => {
+			document.body.dispatchEvent(
+				new PointerEvent("pointerdown", { bubbles: true })
+			);
+		});
+
+		expect(document.querySelector("[data-expression-formula]")).toBeNull();
+	});
+
+	test("second click toggles a pinned popup closed", () => {
+		renderInspector();
+
+		const trigger = container.querySelector(
+			"[data-expression-trigger]"
+		) as HTMLButtonElement;
+
+		act(() => {
+			trigger.click();
+		});
+		expect(document.querySelector("[data-expression-formula]")).toBeTruthy();
+
+		act(() => {
+			trigger.click();
+		});
+		expect(document.querySelector("[data-expression-formula]")).toBeNull();
+	});
+});

--- a/src/app/duckerweb/components/ExpressionInspector.tsx
+++ b/src/app/duckerweb/components/ExpressionInspector.tsx
@@ -1,0 +1,235 @@
+import { Asterisk } from "lucide-react";
+import {
+	useEffect,
+	useEffectEvent,
+	useLayoutEffect,
+	useReducer,
+	useRef,
+	useState,
+	type CSSProperties,
+	type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+import {
+	EXPRESSION_HOVER_DELAY_MS,
+	expressionPopupReducer,
+	isExpressionPopupOpen,
+	type ExpressionPopupMode,
+} from "./expression-popup-state";
+
+type Side = "top" | "right" | "bottom" | "left";
+
+function popupStyleForSide(rect: DOMRect, side: Side): CSSProperties {
+	const gap = 6;
+	switch (side) {
+		case "top":
+			return {
+				top: rect.top - gap,
+				left: rect.left + rect.width / 2,
+				transform: "translate(-50%, -100%)",
+			};
+		case "bottom":
+			return {
+				top: rect.bottom + gap,
+				left: rect.left + rect.width / 2,
+				transform: "translate(-50%, 0)",
+			};
+		case "left":
+			return {
+				top: rect.top + rect.height / 2,
+				left: rect.left - gap,
+				transform: "translate(-100%, -50%)",
+			};
+		case "right":
+			return {
+				top: rect.top + rect.height / 2,
+				left: rect.right + gap,
+				transform: "translate(0, -50%)",
+			};
+		default: {
+			const _exhaustive: never = side;
+			return _exhaustive;
+		}
+	}
+}
+
+export function ExpressionInspector({
+	expression,
+	trigger,
+	className,
+	side = "top",
+}: {
+	expression: string;
+	trigger?: ReactNode;
+	className?: string;
+	side?: Side;
+}) {
+	const [mode, dispatch] = useReducer(
+		expressionPopupReducer,
+		"closed" satisfies ExpressionPopupMode
+	);
+	const triggerRef = useRef<HTMLButtonElement | null>(null);
+	const popupRef = useRef<HTMLDivElement | null>(null);
+	const hoverOpenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const hoverCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const [coords, setCoords] = useState<CSSProperties | null>(null);
+	const open = isExpressionPopupOpen(mode);
+
+	const clearHoverTimers = useEffectEvent(() => {
+		if (hoverOpenTimerRef.current !== null) {
+			clearTimeout(hoverOpenTimerRef.current);
+			hoverOpenTimerRef.current = null;
+		}
+		if (hoverCloseTimerRef.current !== null) {
+			clearTimeout(hoverCloseTimerRef.current);
+			hoverCloseTimerRef.current = null;
+		}
+	});
+
+	useEffect(() => clearHoverTimers, [clearHoverTimers]);
+
+	const scheduleHoverOpen = () => {
+		clearHoverTimers();
+		hoverOpenTimerRef.current = setTimeout(() => {
+			dispatch({ type: "hover-start" });
+			hoverOpenTimerRef.current = null;
+		}, EXPRESSION_HOVER_DELAY_MS);
+	};
+
+	const scheduleHoverClose = () => {
+		clearHoverTimers();
+		hoverCloseTimerRef.current = setTimeout(() => {
+			dispatch({ type: "hover-end" });
+			hoverCloseTimerRef.current = null;
+		}, 80);
+	};
+
+	useLayoutEffect(() => {
+		if (!open || !triggerRef.current) {
+			setCoords(null);
+			return;
+		}
+
+		const update = () => {
+			if (!triggerRef.current) return;
+			setCoords(
+				popupStyleForSide(triggerRef.current.getBoundingClientRect(), side)
+			);
+		};
+
+		update();
+		window.addEventListener("scroll", update, true);
+		window.addEventListener("resize", update);
+		return () => {
+			window.removeEventListener("scroll", update, true);
+			window.removeEventListener("resize", update);
+		};
+	}, [open, side, expression]);
+
+	useEffect(() => {
+		if (mode !== "pinned") return;
+
+		const onPointerDown = (event: PointerEvent) => {
+			const target = event.target as Node | null;
+			if (!target) return;
+			if (triggerRef.current?.contains(target)) return;
+			if (popupRef.current?.contains(target)) return;
+			clearHoverTimers();
+			dispatch({ type: "dismiss" });
+		};
+
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				clearHoverTimers();
+				dispatch({ type: "dismiss" });
+			}
+		};
+
+		document.addEventListener("pointerdown", onPointerDown, true);
+		document.addEventListener("keydown", onKeyDown);
+		return () => {
+			document.removeEventListener("pointerdown", onPointerDown, true);
+			document.removeEventListener("keydown", onKeyDown);
+		};
+	}, [mode, clearHoverTimers]);
+
+	const popup =
+		open && coords && typeof document !== "undefined"
+			? createPortal(
+					<div
+						ref={popupRef}
+						role="dialog"
+						aria-label="Expression"
+						data-expression-popup=""
+						className="z-[100] w-auto max-w-[min(20rem,calc(100vw-1.5rem))] rounded-md border border-[#333] bg-[#1e1e1e] p-2 text-[#f2f2f2] shadow-lg"
+						style={{ position: "fixed", ...coords }}
+						onMouseEnter={() => {
+							if (mode === "pinned") return;
+							clearHoverTimers();
+							dispatch({ type: "hover-start" });
+						}}
+						onMouseLeave={() => {
+							if (mode === "pinned") return;
+							scheduleHoverClose();
+						}}
+					>
+						<div className="mb-1 text-[10px] font-medium tracking-wide text-[#b0b0b0] uppercase">
+							Expression
+						</div>
+						<code
+							data-expression-formula=""
+							className="block max-h-40 overflow-auto font-mono text-[11px] leading-snug break-words whitespace-pre-wrap select-text"
+						>
+							{expression}
+						</code>
+					</div>,
+					document.body
+				)
+			: null;
+
+	return (
+		<>
+			<button
+				ref={triggerRef}
+				type="button"
+				className={cn(
+					"nodrag nopan flex size-3.5 items-center justify-center rounded-[3px] bg-[#444] text-[#f2f2f2]",
+					className
+				)}
+				data-port-option="expression"
+				data-expression-trigger=""
+				aria-label={`Expression: ${expression}`}
+				aria-expanded={open}
+				onMouseEnter={() => {
+					if (mode === "pinned") return;
+					scheduleHoverOpen();
+				}}
+				onMouseLeave={() => {
+					if (mode === "pinned") return;
+					scheduleHoverClose();
+				}}
+				onFocus={() => {
+					if (mode === "pinned") return;
+					scheduleHoverOpen();
+				}}
+				onBlur={() => {
+					if (mode === "pinned") return;
+					scheduleHoverClose();
+				}}
+				onClick={(event) => {
+					event.stopPropagation();
+					clearHoverTimers();
+					dispatch({ type: "click-trigger" });
+				}}
+				onPointerDown={(event) => {
+					// Keep React Flow from starting a node drag on badge press.
+					event.stopPropagation();
+				}}
+			>
+				{trigger ?? <Asterisk size={9} strokeWidth={2.5} />}
+			</button>
+			{popup}
+		</>
+	);
+}

--- a/src/app/duckerweb/components/GHComponentNode.tsx
+++ b/src/app/duckerweb/components/GHComponentNode.tsx
@@ -1,8 +1,11 @@
 import type { GHNodeProps, Port } from "../types/type";
-import { HANDLE_SIZE } from "./constants";
-import { GHHandle } from "./Handle";
+import { resolveComponentExpression } from "../lib/component-expression";
 import { runtimePalette } from "../lib/runtime-palette";
+import { HANDLE_SIZE } from "./constants";
+import { ExpressionInspector } from "./ExpressionInspector";
+import { GHHandle } from "./Handle";
 import { getPortContentWidth, PortLabel } from "./PortOptions";
+
 const SIDE_PADDING_X = 8;
 const LABEL_GAP = 4;
 const APPROX_CHAR_WIDTH = 5.5;
@@ -42,6 +45,7 @@ export function GHComponentNode({ data, selected }: GHNodeProps) {
 		data.runtimeState ?? "normal",
 		data.accentColor
 	);
+	const componentExpression = resolveComponentExpression(data);
 
 	return (
 		<div className="relative overflow-visible">
@@ -63,7 +67,7 @@ export function GHComponentNode({ data, selected }: GHNodeProps) {
 				</div>
 
 				<div
-					className="flex items-center justify-center px-2 py-2"
+					className="relative flex items-center justify-center px-2 py-2"
 					style={{ backgroundColor: palette.center }}
 				>
 					<span
@@ -75,6 +79,14 @@ export function GHComponentNode({ data, selected }: GHNodeProps) {
 					>
 						{data.label}
 					</span>
+					{componentExpression && (
+						<div className="pointer-events-auto absolute top-1 right-1">
+							<ExpressionInspector
+								expression={componentExpression}
+								side="right"
+							/>
+						</div>
+					)}
 				</div>
 
 				<div

--- a/src/app/duckerweb/components/GHPanelNode.tsx
+++ b/src/app/duckerweb/components/GHPanelNode.tsx
@@ -1,10 +1,13 @@
 import type { GHNodeProps } from "../types/type";
+import { resolveInspectableExpression } from "../lib/component-expression";
+import { ExpressionInspector } from "./ExpressionInspector";
 import { GHHandle } from "./Handle";
 import { HandlePosition } from "./HandlePosition";
 
 export function GHPanelNode({ data, selected }: GHNodeProps) {
 	const inputs = data.inputs ?? [];
 	const outputs = data.outputs ?? [];
+	const componentExpression = resolveInspectableExpression(data);
 
 	return (
 		<div className="relative overflow-visible">
@@ -16,6 +19,11 @@ export function GHPanelNode({ data, selected }: GHNodeProps) {
 					backgroundColor: "#fff",
 				}}
 			>
+				{componentExpression && (
+					<div className="pointer-events-auto flex items-center pl-1.5">
+						<ExpressionInspector expression={componentExpression} />
+					</div>
+				)}
 				{data.value !== undefined && data.value !== "" && (
 					<span className="px-2 font-mono text-[10px] text-[#444]">
 						{data.value}

--- a/src/app/duckerweb/components/PortOptions.test.tsx
+++ b/src/app/duckerweb/components/PortOptions.test.tsx
@@ -1,6 +1,18 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { PortLabel } from "./PortOptions";
+
+vi.mock("./ExpressionInspector", () => ({
+	ExpressionInspector: ({ expression }: { expression: string }) => (
+		<span
+			data-port-option="expression"
+			data-expression-trigger=""
+			title={`Expression: ${expression}`}
+		>
+			*
+		</span>
+	),
+}));
 
 describe("PortLabel", () => {
 	test("renders combinable mapping, simplify, reverse, and expression badges", () => {

--- a/src/app/duckerweb/components/PortOptions.tsx
+++ b/src/app/duckerweb/components/PortOptions.tsx
@@ -9,12 +9,15 @@ import {
 import type { PortOptions as ParsedPortOptions } from "parser/src/types";
 import type { CSSProperties } from "react";
 import type { Port } from "../types/type";
+import { ExpressionInspector } from "./ExpressionInspector";
 
 type OptionBadge = {
 	key: string;
 	label: string;
 	Icon: LucideIcon;
 	appearance?: "grasshopper";
+	/** Rendered via ExpressionInspector instead of a static chip. */
+	interactiveExpression?: boolean;
 };
 
 // Grasshopper's simplify glyph: the zipper "Y" — two branches merging
@@ -94,7 +97,12 @@ function getOptionBadges(options?: ParsedPortOptions): OptionBadge[] {
 		badges.push({ key: "reverse", label: "Reverse", Icon: Undo2 });
 	}
 	if (options.expression) {
-		badges.push({ key: "expression", label: "Expression", Icon: Asterisk });
+		badges.push({
+			key: "expression",
+			label: "Expression",
+			Icon: Asterisk,
+			interactiveExpression: true,
+		});
 	}
 
 	return badges;
@@ -129,6 +137,7 @@ export function PortLabel({
 }) {
 	const badges = getOptionBadges(port.options);
 	const summary = optionSummary(port, badges);
+	const expression = port.options?.expression;
 
 	return (
 		<span
@@ -142,24 +151,26 @@ export function PortLabel({
 			}
 		>
 			{badges.length > 0 && (
-				<span className="flex shrink-0 items-center gap-0.5" aria-hidden="true">
-					{badges.map(({ key, label, Icon, appearance }) => (
-						<span
-							key={key}
-							className="flex size-3.5 items-center justify-center rounded-[3px] bg-[#444] text-[#f2f2f2]"
-							data-port-option={key}
-							title={
-								key === "expression" && port.options?.expression
-									? `Expression: ${port.options.expression}`
-									: label
-							}
-						>
-							<Icon
-								size={appearance === "grasshopper" ? 10 : 9}
-								strokeWidth={appearance === "grasshopper" ? 1.5 : 2.5}
-							/>
-						</span>
-					))}
+				<span className="flex shrink-0 items-center gap-0.5">
+					{badges.map(
+						({ key, label, Icon, appearance, interactiveExpression }) =>
+							interactiveExpression && expression ? (
+								<ExpressionInspector key={key} expression={expression} />
+							) : (
+								<span
+									key={key}
+									className="flex size-3.5 items-center justify-center rounded-[3px] bg-[#444] text-[#f2f2f2]"
+									data-port-option={key}
+									title={label}
+									aria-hidden="true"
+								>
+									<Icon
+										size={appearance === "grasshopper" ? 10 : 9}
+										strokeWidth={appearance === "grasshopper" ? 1.5 : 2.5}
+									/>
+								</span>
+							)
+					)}
 				</span>
 			)}
 			<span className="min-w-0">{port.label}</span>

--- a/src/app/duckerweb/components/expression-popup-state.test.ts
+++ b/src/app/duckerweb/components/expression-popup-state.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import {
+	expressionPopupReducer,
+	isExpressionPopupOpen,
+	type ExpressionPopupMode,
+} from "./expression-popup-state";
+
+describe("expressionPopupReducer", () => {
+	test("opens on hover and closes when the pointer leaves", () => {
+		let mode: ExpressionPopupMode = "closed";
+		mode = expressionPopupReducer(mode, { type: "hover-start" });
+		expect(mode).toBe("hover");
+		expect(isExpressionPopupOpen(mode)).toBe(true);
+
+		mode = expressionPopupReducer(mode, { type: "hover-end" });
+		expect(mode).toBe("closed");
+		expect(isExpressionPopupOpen(mode)).toBe(false);
+	});
+
+	test("click pins the popup and ignores hover-end while pinned", () => {
+		let mode: ExpressionPopupMode = "closed";
+		mode = expressionPopupReducer(mode, { type: "click-trigger" });
+		expect(mode).toBe("pinned");
+
+		mode = expressionPopupReducer(mode, { type: "hover-end" });
+		expect(mode).toBe("pinned");
+
+		mode = expressionPopupReducer(mode, { type: "hover-start" });
+		expect(mode).toBe("pinned");
+	});
+
+	test("second click toggles a pinned popup closed", () => {
+		let mode: ExpressionPopupMode = "hover";
+		mode = expressionPopupReducer(mode, { type: "click-trigger" });
+		expect(mode).toBe("pinned");
+
+		mode = expressionPopupReducer(mode, { type: "click-trigger" });
+		expect(mode).toBe("closed");
+	});
+
+	test("dismiss closes hover and pinned states", () => {
+		expect(expressionPopupReducer("hover", { type: "dismiss" })).toBe("closed");
+		expect(expressionPopupReducer("pinned", { type: "dismiss" })).toBe(
+			"closed"
+		);
+	});
+});

--- a/src/app/duckerweb/components/expression-popup-state.ts
+++ b/src/app/duckerweb/components/expression-popup-state.ts
@@ -1,0 +1,33 @@
+export type ExpressionPopupMode = "closed" | "hover" | "pinned";
+
+export type ExpressionPopupAction =
+	| { type: "hover-start" }
+	| { type: "hover-end" }
+	| { type: "click-trigger" }
+	| { type: "dismiss" };
+
+export const EXPRESSION_HOVER_DELAY_MS = 150;
+
+export function expressionPopupReducer(
+	state: ExpressionPopupMode,
+	action: ExpressionPopupAction
+): ExpressionPopupMode {
+	switch (action.type) {
+		case "hover-start":
+			return state === "pinned" ? "pinned" : "hover";
+		case "hover-end":
+			return state === "pinned" ? "pinned" : "closed";
+		case "click-trigger":
+			return state === "pinned" ? "closed" : "pinned";
+		case "dismiss":
+			return "closed";
+		default: {
+			const _exhaustive: never = action;
+			return _exhaustive;
+		}
+	}
+}
+
+export function isExpressionPopupOpen(mode: ExpressionPopupMode): boolean {
+	return mode !== "closed";
+}

--- a/src/app/duckerweb/gh-flow-generator.test.ts
+++ b/src/app/duckerweb/gh-flow-generator.test.ts
@@ -124,6 +124,8 @@ test("generateFlowData exposes standalone parameter internal expressions", () =>
 	expect(node?.data.outputs[0]?.options?.expression).toBe(
 		component.internalExpression
 	);
+	expect(node?.data.componentExpression).toBe(component.internalExpression);
+	expect(node?.data.internalExpression).toBe(component.internalExpression);
 
 	const mappedParameter = Object.values(parsed.components).find(
 		(candidate) =>

--- a/src/app/duckerweb/lib/component-expression.test.ts
+++ b/src/app/duckerweb/lib/component-expression.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import {
+	resolveComponentExpression,
+	resolveInspectableExpression,
+} from "./component-expression";
+
+describe("resolveComponentExpression", () => {
+	test("prefers componentExpression, then internalExpression, then expression", () => {
+		expect(
+			resolveComponentExpression({
+				componentExpression: "x/2",
+				internalExpression: "y",
+				expression: "z",
+			})
+		).toBe("x/2");
+		expect(
+			resolveComponentExpression({
+				internalExpression: "a+1",
+			})
+		).toBe("a+1");
+		expect(
+			resolveComponentExpression({
+				expression: 'Format("{0}", x)',
+			})
+		).toBe('Format("{0}", x)');
+	});
+
+	test("does not fall back to port options", () => {
+		expect(
+			resolveComponentExpression({
+				outputs: [{ id: "b", label: "R", options: { expression: "x*2" } }],
+			})
+		).toBeUndefined();
+	});
+});
+
+describe("resolveInspectableExpression", () => {
+	test("falls back to a port expression for compact value nodes", () => {
+		expect(
+			resolveInspectableExpression({
+				outputs: [
+					{ id: "a", label: "V" },
+					{ id: "b", label: "R", options: { expression: "x*2" } },
+				],
+			})
+		).toBe("x*2");
+	});
+});

--- a/src/app/duckerweb/lib/component-expression.ts
+++ b/src/app/duckerweb/lib/component-expression.ts
@@ -1,0 +1,42 @@
+import type { GHNodeData, Port } from "../types/type";
+
+export type ExpressionFields = {
+	componentExpression?: unknown;
+	internalExpression?: unknown;
+	expression?: unknown;
+	outputs?: Port[];
+};
+
+/** Component-level formulas only (Expression / InternalExpression). */
+export function resolveComponentExpression(
+	data: ExpressionFields
+): string | undefined {
+	if (
+		typeof data.componentExpression === "string" &&
+		data.componentExpression
+	) {
+		return data.componentExpression;
+	}
+	if (typeof data.internalExpression === "string" && data.internalExpression) {
+		return data.internalExpression;
+	}
+	if (typeof data.expression === "string" && data.expression) {
+		return data.expression;
+	}
+	return undefined;
+}
+
+/**
+ * For compact value/panel nodes that don't render port labels, also accept a
+ * port-level expression folded onto the single output.
+ */
+export function resolveInspectableExpression(
+	data: ExpressionFields | Pick<GHNodeData, "outputs">
+): string | undefined {
+	const componentLevel = resolveComponentExpression(data);
+	if (componentLevel) return componentLevel;
+
+	const fromOutput = data.outputs?.find((port) => port.options?.expression)
+		?.options?.expression;
+	return fromOutput || undefined;
+}

--- a/src/app/duckerweb/lib/component-handler.ts
+++ b/src/app/duckerweb/lib/component-handler.ts
@@ -53,6 +53,14 @@ export function handleComponent(
 		value: extractValue(component),
 		height: position.height,
 	};
+
+	const componentExpression =
+		component.internalExpression ?? component.expression;
+	if (componentExpression) {
+		nodeData.internalExpression = component.internalExpression;
+		nodeData.expression = component.expression;
+		nodeData.componentExpression = componentExpression;
+	}
 	const runtimeClasses = [
 		component.state?.hidden && "gh-runtime-node--hidden",
 		(component.state?.locked || component.state?.frozen) &&

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -74,6 +74,7 @@ export default defineConfig(({ mode }) => {
 			nitro(),
 		],
 		resolve: {
+			dedupe: ["react", "react-dom"],
 			alias: [
 				{
 					find: "use-sync-external-store/shim/index.js",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace native `title` tooltips on expression badges with a hoverable, click-to-pin inspector (Escape / outside click dismisses; text is selectable and wraps).
- Surface component-level `expression` / `internalExpression` on flow nodes (value/panel and component headers), not only via folded port options.
- Add focused vitest coverage for popup state, PortLabel badge wiring, and inspector pin/dismiss behavior.

Closes #116

## Merge order
Stacked on #115 (`t3code/port-diff-copy`), which is stacked on #114. Merge only after #114 and #115.

## Test plan
- [x] `pnpm exec vitest run src/app/duckerweb/components/PortOptions.test.tsx src/app/duckerweb/components/ExpressionInspector.test.tsx src/app/duckerweb/components/expression-popup-state.test.ts src/app/duckerweb/lib/component-expression.test.ts src/app/duckerweb/gh-flow-generator.test.ts --pool=forks`
- [x] `pnpm exec tsc --noEmit`
- [ ] Manually in `/duckerweb`: hover expression `*` badge → formula appears; click to pin; click outside / Escape to dismiss; copy formula text
- [ ] Confirm Number/`internalExpression` and Expression-component formulas are inspectable from the flow canvas

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7476-6954-7a08-aee9-489a21957b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7476-6954-7a08-aee9-489a21957b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

