### PR TITLE
Landing review: five interactive variants (/lp1–/lp5)

### DIFF
--- a/src/app/landing/ctas.tsx
+++ b/src/app/landing/ctas.tsx
@@ -1,0 +1,48 @@
+import { SignUpButton } from "@clerk/tanstack-react-start";
+import { Link } from "@tanstack/react-router";
+import { ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function PrimarySignUp({
+	label = "Get Started Free",
+	className,
+}: {
+	label?: string;
+	className?: string;
+}) {
+	return (
+		<SignUpButton mode="modal">
+			<button
+				type="button"
+				className={cn(
+					"inline-flex items-center gap-2 rounded-md bg-white px-5 py-2.5 text-sm font-semibold text-black transition-colors hover:bg-neutral-200",
+					className
+				)}
+			>
+				{label}
+				<ArrowRight className="h-4 w-4" />
+			</button>
+		</SignUpButton>
+	);
+}
+
+export function SecondaryDuckerLink({
+	label = "Open DuckerWeb",
+	className,
+}: {
+	label?: string;
+	className?: string;
+}) {
+	return (
+		<Link
+			to="/duckerweb"
+			className={cn(
+				"inline-flex items-center gap-2 rounded-md border border-neutral-600 px-5 py-2.5 text-sm font-medium text-neutral-200 transition-colors hover:border-neutral-400 hover:bg-neutral-900",
+				className
+			)}
+		>
+			{label}
+			<ArrowRight className="h-4 w-4" />
+		</Link>
+	);
+}

--- a/src/app/landing/ctas.tsx
+++ b/src/app/landing/ctas.tsx
@@ -46,3 +46,54 @@ export function SecondaryDuckerLink({
 		</Link>
 	);
 }
+
+/** Shared product framing used across review variants */
+export function ProductContrast({
+	emphasis = "clip",
+}: {
+	emphasis?: "clip" | "ducker" | "equal";
+}) {
+	return (
+		<div className="grid gap-4 md:grid-cols-2">
+			<div
+				className={cn(
+					"rounded-xl border p-5 transition-colors",
+					emphasis === "ducker"
+						? "border-neutral-800 bg-neutral-950/60"
+						: "border-neutral-600 bg-neutral-900"
+				)}
+			>
+				<p className="text-[11px] tracking-[0.16em] text-neutral-500 uppercase">
+					Hopper Clip
+				</p>
+				<p className="mt-2 text-lg font-semibold text-white">
+					Online pastebin for Grasshopper
+				</p>
+				<p className="mt-2 text-sm leading-relaxed text-neutral-400">
+					Save definitions to your account, organize with tags, and share a link
+					— so scripts live online instead of in file attachments.
+				</p>
+			</div>
+			<div
+				className={cn(
+					"rounded-xl border p-5 transition-colors",
+					emphasis === "clip"
+						? "border-neutral-800 bg-neutral-950/60"
+						: "border-neutral-600 bg-neutral-900"
+				)}
+			>
+				<p className="text-[11px] tracking-[0.16em] text-neutral-500 uppercase">
+					DuckerWeb
+				</p>
+				<p className="mt-2 text-lg font-semibold text-white">
+					Local-first .gh file inspector
+				</p>
+				<p className="mt-2 text-sm leading-relaxed text-neutral-400">
+					Open a file in your browser to see the graph, list components, diff
+					two versions, and inspect expressions — nothing is uploaded unless you
+					choose to save a card.
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/src/app/landing/shell.tsx
+++ b/src/app/landing/shell.tsx
@@ -28,7 +28,9 @@ export function LandingShell({
 			: VARIANTS.find((v) => v.path === active);
 
 	return (
-		<div className={cn("min-h-screen bg-black font-sans text-white", className)}>
+		<div
+			className={cn("min-h-screen bg-black font-sans text-white", className)}
+		>
 			<div className="mx-auto flex min-h-screen max-w-400 flex-col p-4 md:px-6 md:pt-6 md:pb-2">
 				<Header />
 				<div className="mb-4 flex flex-wrap items-center justify-between gap-3 border-b border-neutral-800 pb-3">
@@ -41,7 +43,10 @@ export function LandingShell({
 							<span className="text-neutral-600">· pick a version</span>
 						</p>
 					</div>
-					<nav className="flex items-center gap-1.5" aria-label="Landing variants">
+					<nav
+						className="flex items-center gap-1.5"
+						aria-label="Landing variants"
+					>
 						<Link
 							to="/lp"
 							className={cn(

--- a/src/app/landing/shell.tsx
+++ b/src/app/landing/shell.tsx
@@ -1,0 +1,80 @@
+import { Link } from "@tanstack/react-router";
+import Footer from "@/app/components/footer";
+import Header from "@/app/components/header";
+import { cn } from "@/lib/utils";
+
+const VARIANTS = [
+	{ path: "/lp1", label: "1", title: "Diff Theater" },
+	{ path: "/lp2", label: "2", title: "Paste Lab" },
+	{ path: "/lp3", label: "3", title: "Expression Lab" },
+	{ path: "/lp4", label: "4", title: "Split Story" },
+	{ path: "/lp5", label: "5", title: "Product Tour" },
+] as const;
+
+export type LandingVariantId = (typeof VARIANTS)[number]["path"] | "/lp";
+
+export function LandingShell({
+	active,
+	children,
+	className,
+}: {
+	active: LandingVariantId;
+	children: React.ReactNode;
+	className?: string;
+}) {
+	const current =
+		active === "/lp"
+			? { title: "Gallery" }
+			: VARIANTS.find((v) => v.path === active);
+
+	return (
+		<div className={cn("min-h-screen bg-black font-sans text-white", className)}>
+			<div className="mx-auto flex min-h-screen max-w-400 flex-col p-4 md:px-6 md:pt-6 md:pb-2">
+				<Header />
+				<div className="mb-4 flex flex-wrap items-center justify-between gap-3 border-b border-neutral-800 pb-3">
+					<div className="flex flex-col gap-0.5">
+						<p className="text-[11px] tracking-[0.18em] text-neutral-500 uppercase">
+							Landing review
+						</p>
+						<p className="text-sm text-neutral-300">
+							{current?.title ?? "Variant"}{" "}
+							<span className="text-neutral-600">· pick a version</span>
+						</p>
+					</div>
+					<nav className="flex items-center gap-1.5" aria-label="Landing variants">
+						<Link
+							to="/lp"
+							className={cn(
+								"rounded-md px-2 py-1 text-xs transition-colors",
+								active === "/lp"
+									? "bg-white text-black"
+									: "text-neutral-500 hover:bg-neutral-900 hover:text-white"
+							)}
+						>
+							All
+						</Link>
+						{VARIANTS.map((variant) => (
+							<Link
+								key={variant.path}
+								to={variant.path}
+								className={cn(
+									"rounded-md px-2.5 py-1 font-mono text-xs transition-colors",
+									active === variant.path
+										? "bg-white text-black"
+										: "bg-neutral-900 text-neutral-400 hover:bg-neutral-800 hover:text-white"
+								)}
+								title={variant.title}
+							>
+								{variant.label}
+							</Link>
+						))}
+					</nav>
+				</div>
+				<main className="flex-1">{children}</main>
+				<Footer />
+			</div>
+		</div>
+	);
+}
+
+export { VARIANTS as LANDING_VARIANTS };

--- a/src/app/landing/variants/lp1-diff-theater.tsx
+++ b/src/app/landing/variants/lp1-diff-theater.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
-import { PrimarySignUp, SecondaryDuckerLink } from "../ctas";
+import { PrimarySignUp, SecondaryDuckerLink, ProductContrast } from "../ctas";
 
 type Stage = "original" | "changed" | "diff";
 
@@ -15,10 +15,40 @@ type DemoNode = {
 };
 
 const NODES: DemoNode[] = [
-	{ id: "a", label: "Point", x: 8, y: 28, kind: "component", status: "unchanged" },
-	{ id: "b", label: "Number", x: 8, y: 58, kind: "value", status: "modified", change: "Value 2.0 → 3.5" },
-	{ id: "c", label: "Move", x: 38, y: 42, kind: "component", status: "modified", change: "Input G: Expression added" },
-	{ id: "d", label: "Panel", x: 68, y: 28, kind: "component", status: "removed" },
+	{
+		id: "a",
+		label: "Point",
+		x: 8,
+		y: 28,
+		kind: "component",
+		status: "unchanged",
+	},
+	{
+		id: "b",
+		label: "Number",
+		x: 8,
+		y: 58,
+		kind: "value",
+		status: "modified",
+		change: "Value 2.0 → 3.5",
+	},
+	{
+		id: "c",
+		label: "Move",
+		x: 38,
+		y: 42,
+		kind: "component",
+		status: "modified",
+		change: "Input G: Expression added",
+	},
+	{
+		id: "d",
+		label: "Panel",
+		x: 68,
+		y: 28,
+		kind: "component",
+		status: "removed",
+	},
 	{ id: "e", label: "Cull", x: 68, y: 58, kind: "component", status: "added" },
 ];
 
@@ -61,31 +91,34 @@ export function Lp1DiffTheater() {
 						"linear-gradient(#2a2a28 1px, transparent 1px), linear-gradient(90deg, #2a2a28 1px, transparent 1px)",
 					backgroundSize: "40px 40px",
 					backgroundColor: "#121210",
-					maskImage:
-						"linear-gradient(to bottom, black 40%, transparent 95%)",
+					maskImage: "linear-gradient(to bottom, black 40%, transparent 95%)",
 				}}
 			/>
 
-			<section className="relative grid min-h-[70vh] items-center gap-10 pt-6 lg:grid-cols-[1.05fr_0.95fr]">
+			<section className="relative grid min-h-[68vh] items-center gap-10 pt-6 lg:grid-cols-[1.05fr_0.95fr]">
 				<div className="max-w-xl">
 					<p className="mb-3 text-5xl font-bold tracking-tight md:text-6xl">
 						Hopper Clip
 					</p>
 					<h1 className="text-2xl font-semibold text-neutral-100 md:text-3xl">
-						See what actually changed in a Grasshopper definition.
+						Online pastebin for Grasshopper — and a local-first way to look
+						inside .gh files.
 					</h1>
 					<p className="mt-4 text-base text-neutral-400 md:text-lg">
-						DuckerWeb Diff matches components by instance GUID, then paints
-						adds, edits, and removals — including port mapping and expression
-						details.
+						Save scripts to your account and share a link. Need to peek or Diff
+						two versions? Open them in DuckerWeb — nothing uploads unless you
+						save a card.
 					</p>
 					<div className="mt-8 flex flex-wrap gap-3">
 						<PrimarySignUp />
-						<SecondaryDuckerLink label="Try Diff in DuckerWeb" />
+						<SecondaryDuckerLink label="Try Diff locally" />
 					</div>
 				</div>
 
 				<div className="relative">
+					<p className="mb-2 text-xs tracking-[0.14em] text-neutral-500 uppercase">
+						DuckerWeb · interactive Diff demo
+					</p>
 					<div className="mb-3 flex gap-1 rounded-lg border border-neutral-800 bg-neutral-950/80 p-1">
 						{(
 							[
@@ -128,7 +161,7 @@ export function Lp1DiffTheater() {
 							<path
 								d="M 18% 35% C 30% 35%, 30% 48%, 40% 48%"
 								fill="none"
-								stroke={stage === "diff" ? "#5a5a5a" : "#5a5a5a"}
+								stroke="#5a5a5a"
 								strokeWidth="2"
 							/>
 							<path
@@ -179,7 +212,9 @@ export function Lp1DiffTheater() {
 								className={cn(
 									"absolute -translate-x-1/2 -translate-y-1/2 rounded-sm px-2.5 py-1.5 text-[11px] font-medium text-neutral-900 shadow-sm ring-2 transition-all duration-300",
 									node.kind === "value" ? "bg-[#f5f07a]" : "bg-[#b8b5ae]",
-									stage === "diff" ? statusRing[node.status] : "ring-transparent",
+									stage === "diff"
+										? statusRing[node.status]
+										: "ring-transparent",
 									focusId === node.id && stage === "diff"
 										? "scale-105 ring-offset-1 ring-offset-[#ccc9c0]"
 										: ""
@@ -211,7 +246,9 @@ export function Lp1DiffTheater() {
 								<p className="text-xs text-neutral-500">
 									Changed component · {focused.label}
 								</p>
-								<p className="mt-1 text-sm text-neutral-200">{focused.change}</p>
+								<p className="mt-1 text-sm text-neutral-200">
+									{focused.change}
+								</p>
 							</>
 						) : (
 							<p className="text-sm text-neutral-500">
@@ -224,12 +261,9 @@ export function Lp1DiffTheater() {
 				</div>
 			</section>
 
-			<section className="relative mt-16 max-w-3xl">
-				<h2 className="text-xl font-semibold">Share the definition. Inspect the delta.</h2>
-				<p className="mt-2 text-neutral-400">
-					Hopper Clip stores and shares your scripts. DuckerWeb Diff tells you
-					exactly what logic moved — not just that the canvas was rearranged.
-				</p>
+			<section className="relative mt-16">
+				<h2 className="mb-4 text-xl font-semibold">Two tools, one product</h2>
+				<ProductContrast emphasis="ducker" />
 			</section>
 		</div>
 	);

--- a/src/app/landing/variants/lp1-diff-theater.tsx
+++ b/src/app/landing/variants/lp1-diff-theater.tsx
@@ -1,0 +1,236 @@
+import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import { PrimarySignUp, SecondaryDuckerLink } from "../ctas";
+
+type Stage = "original" | "changed" | "diff";
+
+type DemoNode = {
+	id: string;
+	label: string;
+	x: number;
+	y: number;
+	kind: "component" | "value";
+	status: "unchanged" | "added" | "modified" | "removed";
+	change?: string;
+};
+
+const NODES: DemoNode[] = [
+	{ id: "a", label: "Point", x: 8, y: 28, kind: "component", status: "unchanged" },
+	{ id: "b", label: "Number", x: 8, y: 58, kind: "value", status: "modified", change: "Value 2.0 → 3.5" },
+	{ id: "c", label: "Move", x: 38, y: 42, kind: "component", status: "modified", change: "Input G: Expression added" },
+	{ id: "d", label: "Panel", x: 68, y: 28, kind: "component", status: "removed" },
+	{ id: "e", label: "Cull", x: 68, y: 58, kind: "component", status: "added" },
+];
+
+const statusRing: Record<DemoNode["status"], string> = {
+	unchanged: "ring-transparent opacity-40",
+	added: "ring-green-400/80",
+	modified: "ring-yellow-300/80",
+	removed: "ring-red-400/80 opacity-70",
+};
+
+export function Lp1DiffTheater() {
+	const [stage, setStage] = useState<Stage>("diff");
+	const [focusId, setFocusId] = useState<string | null>("c");
+
+	const visible = useMemo(() => {
+		if (stage === "original") {
+			return NODES.filter((n) => n.status !== "added").map((n) => ({
+				...n,
+				status: "unchanged" as const,
+			}));
+		}
+		if (stage === "changed") {
+			return NODES.filter((n) => n.status !== "removed").map((n) => ({
+				...n,
+				status: "unchanged" as const,
+			}));
+		}
+		return NODES;
+	}, [stage]);
+
+	const focused = NODES.find((n) => n.id === focusId);
+
+	return (
+		<div className="relative overflow-hidden pb-16">
+			<div
+				aria-hidden
+				className="pointer-events-none absolute inset-x-0 top-0 h-[70vh] opacity-40"
+				style={{
+					backgroundImage:
+						"linear-gradient(#2a2a28 1px, transparent 1px), linear-gradient(90deg, #2a2a28 1px, transparent 1px)",
+					backgroundSize: "40px 40px",
+					backgroundColor: "#121210",
+					maskImage:
+						"linear-gradient(to bottom, black 40%, transparent 95%)",
+				}}
+			/>
+
+			<section className="relative grid min-h-[70vh] items-center gap-10 pt-6 lg:grid-cols-[1.05fr_0.95fr]">
+				<div className="max-w-xl">
+					<p className="mb-3 text-5xl font-bold tracking-tight md:text-6xl">
+						Hopper Clip
+					</p>
+					<h1 className="text-2xl font-semibold text-neutral-100 md:text-3xl">
+						See what actually changed in a Grasshopper definition.
+					</h1>
+					<p className="mt-4 text-base text-neutral-400 md:text-lg">
+						DuckerWeb Diff matches components by instance GUID, then paints
+						adds, edits, and removals — including port mapping and expression
+						details.
+					</p>
+					<div className="mt-8 flex flex-wrap gap-3">
+						<PrimarySignUp />
+						<SecondaryDuckerLink label="Try Diff in DuckerWeb" />
+					</div>
+				</div>
+
+				<div className="relative">
+					<div className="mb-3 flex gap-1 rounded-lg border border-neutral-800 bg-neutral-950/80 p-1">
+						{(
+							[
+								["original", "Original"],
+								["changed", "Changed"],
+								["diff", "Diff"],
+							] as const
+						).map(([id, label]) => (
+							<button
+								key={id}
+								type="button"
+								onClick={() => setStage(id)}
+								className={cn(
+									"flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+									stage === id
+										? "bg-neutral-200 text-black"
+										: "text-neutral-400 hover:text-white"
+								)}
+							>
+								{label}
+							</button>
+						))}
+					</div>
+
+					<div
+						className="relative aspect-[4/3] overflow-hidden rounded-xl border border-neutral-700"
+						style={{ backgroundColor: "#ccc9c0" }}
+					>
+						<div
+							aria-hidden
+							className="absolute inset-0"
+							style={{
+								backgroundImage:
+									"linear-gradient(#bbb8af 1px, transparent 1px), linear-gradient(90deg, #bbb8af 1px, transparent 1px)",
+								backgroundSize: "32px 32px",
+							}}
+						/>
+
+						<svg className="absolute inset-0 h-full w-full" aria-hidden>
+							<path
+								d="M 18% 35% C 30% 35%, 30% 48%, 40% 48%"
+								fill="none"
+								stroke={stage === "diff" ? "#5a5a5a" : "#5a5a5a"}
+								strokeWidth="2"
+							/>
+							<path
+								d="M 18% 65% C 30% 65%, 30% 48%, 40% 48%"
+								fill="none"
+								stroke="#5a5a5a"
+								strokeWidth="2"
+							/>
+							{stage === "diff" ? (
+								<>
+									<path
+										d="M 52% 48% C 60% 48%, 60% 35%, 70% 35%"
+										fill="none"
+										stroke="#ef4444"
+										strokeWidth="2"
+										strokeDasharray="4 3"
+										opacity="0.85"
+									/>
+									<path
+										d="M 52% 48% C 60% 48%, 60% 65%, 70% 65%"
+										fill="none"
+										stroke="#22c55e"
+										strokeWidth="2"
+									/>
+								</>
+							) : stage === "original" ? (
+								<path
+									d="M 52% 48% C 60% 48%, 60% 35%, 70% 35%"
+									fill="none"
+									stroke="#5a5a5a"
+									strokeWidth="2"
+								/>
+							) : (
+								<path
+									d="M 52% 48% C 60% 48%, 60% 65%, 70% 65%"
+									fill="none"
+									stroke="#5a5a5a"
+									strokeWidth="2"
+								/>
+							)}
+						</svg>
+
+						{visible.map((node) => (
+							<button
+								key={node.id}
+								type="button"
+								onClick={() => setFocusId(node.id)}
+								className={cn(
+									"absolute -translate-x-1/2 -translate-y-1/2 rounded-sm px-2.5 py-1.5 text-[11px] font-medium text-neutral-900 shadow-sm ring-2 transition-all duration-300",
+									node.kind === "value" ? "bg-[#f5f07a]" : "bg-[#b8b5ae]",
+									stage === "diff" ? statusRing[node.status] : "ring-transparent",
+									focusId === node.id && stage === "diff"
+										? "scale-105 ring-offset-1 ring-offset-[#ccc9c0]"
+										: ""
+								)}
+								style={{ left: `${node.x}%`, top: `${node.y}%` }}
+							>
+								{node.label}
+							</button>
+						))}
+
+						{stage === "diff" ? (
+							<div className="absolute right-3 bottom-3 left-3 flex flex-wrap gap-2 text-[10px] font-medium">
+								<span className="rounded bg-green-500/20 px-2 py-1 text-green-900 ring-1 ring-green-600/40">
+									+1 added
+								</span>
+								<span className="rounded bg-yellow-400/30 px-2 py-1 text-yellow-950 ring-1 ring-yellow-600/40">
+									~2 modified
+								</span>
+								<span className="rounded bg-red-500/20 px-2 py-1 text-red-900 ring-1 ring-red-600/40">
+									−1 removed
+								</span>
+							</div>
+						) : null}
+					</div>
+
+					<div className="mt-3 min-h-16 rounded-lg border border-neutral-800 bg-neutral-950 px-4 py-3">
+						{stage === "diff" && focused?.change ? (
+							<>
+								<p className="text-xs text-neutral-500">
+									Changed component · {focused.label}
+								</p>
+								<p className="mt-1 text-sm text-neutral-200">{focused.change}</p>
+							</>
+						) : (
+							<p className="text-sm text-neutral-500">
+								{stage === "diff"
+									? "Click a highlighted node to read the change detail."
+									: "Flip to Diff to overlay adds, edits, and removals."}
+							</p>
+						)}
+					</div>
+				</div>
+			</section>
+
+			<section className="relative mt-16 max-w-3xl">
+				<h2 className="text-xl font-semibold">Share the definition. Inspect the delta.</h2>
+				<p className="mt-2 text-neutral-400">
+					Hopper Clip stores and shares your scripts. DuckerWeb Diff tells you
+					exactly what logic moved — not just that the canvas was rearranged.
+				</p>
+			</section>
+		</div>
+	);
+}

--- a/src/app/landing/variants/lp2-paste-lab.tsx
+++ b/src/app/landing/variants/lp2-paste-lab.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { FileUp, Link2, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useModifierKeyLabel } from "@/app/hooks/use-modifier-key-label";
-import { PrimarySignUp, SecondaryDuckerLink } from "../ctas";
+import { PrimarySignUp, SecondaryDuckerLink, ProductContrast } from "../ctas";
 
 type Phase = "idle" | "catching" | "validating" | "ready";
 
@@ -45,7 +45,7 @@ export function Lp2PasteLab() {
 
 	return (
 		<div className="pb-16">
-			<section className="relative flex min-h-[72vh] flex-col justify-center pt-4">
+			<section className="relative flex min-h-[68vh] flex-col justify-center pt-4">
 				<div
 					aria-hidden
 					className={cn(
@@ -63,19 +63,15 @@ export function Lp2PasteLab() {
 						Hopper Clip
 					</p>
 					<h1 className="mt-4 text-2xl font-semibold text-neutral-100 md:text-3xl">
-						Paste a definition. Skip the zip.
+						Pastebin for Grasshopper — save online, or inspect locally first.
 					</h1>
 					<p className="mx-auto mt-4 max-w-xl text-base text-neutral-400 md:text-lg">
-						Native {modifier}+V imports GhXml without clipboard permission
-						prompts. Or drop a{" "}
+						{modifier}+V or drop a{" "}
 						<code className="rounded bg-neutral-800 px-1.5 py-0.5 text-sm">
 							.gh
 						</code>{" "}
-						/{" "}
-						<code className="rounded bg-neutral-800 px-1.5 py-0.5 text-sm">
-							.ghx
-						</code>{" "}
-						file — same pipeline.
+						file. Save it as a card with a shareable link, or open it in
+						DuckerWeb to browse the graph without uploading.
 					</p>
 				</div>
 
@@ -83,7 +79,7 @@ export function Lp2PasteLab() {
 					className={cn(
 						"relative z-10 mx-auto mt-10 w-full max-w-2xl overflow-hidden rounded-2xl border transition-all duration-300",
 						dragOver
-							? "border-white bg-neutral-900 scale-[1.01]"
+							? "scale-[1.01] border-white bg-neutral-900"
 							: "border-neutral-700 bg-neutral-950",
 						phase === "ready" && "border-emerald-500/40"
 					)}
@@ -102,7 +98,7 @@ export function Lp2PasteLab() {
 					<div className="flex min-h-56 flex-col items-center justify-center gap-4 px-6 py-10 text-center">
 						{phase === "idle" || phase === "catching" ? (
 							<>
-								<div className="flex items-center gap-3 text-neutral-300">
+								<div className="flex flex-wrap items-center justify-center gap-3 text-neutral-300">
 									<span className="inline-flex items-center gap-2 rounded-md border border-neutral-600 px-3 py-1.5 font-mono text-sm">
 										{modifier}+V
 									</span>
@@ -113,8 +109,8 @@ export function Lp2PasteLab() {
 									</span>
 								</div>
 								<p className="max-w-sm text-sm text-neutral-500">
-									Press {modifier}+V anywhere on this page, click Simulate paste,
-									or drop a file on this zone.
+									Try it here: press {modifier}+V, click Simulate paste, or drop
+									any file on this zone.
 								</p>
 								<button
 									type="button"
@@ -130,31 +126,44 @@ export function Lp2PasteLab() {
 							<div className="flex flex-col items-center gap-3">
 								<div className="h-8 w-8 animate-spin rounded-full border-2 border-neutral-600 border-t-white" />
 								<p className="text-sm text-neutral-300">
-									Validating GhXml from {source === "drop" ? "file" : "clipboard"}…
+									Validating GhXml from{" "}
+									{source === "drop" ? "file" : "clipboard"}…
 								</p>
 							</div>
 						) : null}
 
 						{phase === "ready" ? (
-							<div className="flex w-full max-w-md flex-col items-stretch gap-4 animate-in fade-in duration-500">
+							<div className="flex w-full max-w-md flex-col items-stretch gap-4">
 								<div className="flex items-start gap-3 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-left">
-									<Sparkles className="mt-0.5 h-4 w-4 text-emerald-300" />
+									<Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300" />
 									<div>
 										<p className="text-sm font-medium text-emerald-100">
 											Definition ready
 										</p>
 										<p className="mt-1 text-xs text-emerald-200/70">
-											Sun path · 12 components · imported via{" "}
+											Sun path · 12 components · via{" "}
 											{source === "drop" ? "file drop" : `${modifier}+V`}
 										</p>
 									</div>
 								</div>
-								<div className="flex items-center justify-between rounded-lg border border-neutral-700 bg-neutral-900 px-4 py-3">
-									<div className="flex items-center gap-2 text-sm text-neutral-300">
-										<Link2 className="h-4 w-4 text-neutral-500" />
-										hopperclip.com/s/sun-path
+								<div className="grid gap-2 sm:grid-cols-2">
+									<div className="rounded-lg border border-neutral-700 bg-neutral-900 px-3 py-3 text-left">
+										<p className="text-[11px] text-neutral-500 uppercase">
+											Save online
+										</p>
+										<p className="mt-1 flex items-center gap-1.5 text-sm text-neutral-200">
+											<Link2 className="h-3.5 w-3.5 text-neutral-500" />
+											hopperclip.com/s/…
+										</p>
 									</div>
-									<span className="text-xs text-neutral-500">shareable</span>
+									<div className="rounded-lg border border-neutral-700 bg-neutral-900 px-3 py-3 text-left">
+										<p className="text-[11px] text-neutral-500 uppercase">
+											Or inspect locally
+										</p>
+										<p className="mt-1 text-sm text-neutral-200">
+											DuckerWeb · no upload
+										</p>
+									</div>
 								</div>
 								<button
 									type="button"
@@ -176,28 +185,11 @@ export function Lp2PasteLab() {
 						</div>
 					) : null}
 				</div>
-
-				<div className="relative z-10 mt-8 flex flex-wrap justify-center gap-3">
-					<PrimarySignUp label="Start clipping" />
-					<SecondaryDuckerLink label="Paste into DuckerWeb" />
-				</div>
 			</section>
 
-			<section className="mx-auto mt-8 grid max-w-3xl gap-6 md:grid-cols-2">
-				<div>
-					<h2 className="text-lg font-semibold">Cards & Diff share the same paste</h2>
-					<p className="mt-2 text-sm text-neutral-400">
-						On /ghcards, paste opens create-card. In DuckerWeb Diff, paste targets
-						the comparison definition. Field pastes stay normal.
-					</p>
-				</div>
-				<div>
-					<h2 className="text-lg font-semibold">Native .gh decoding</h2>
-					<p className="mt-2 text-sm text-neutral-400">
-						Saved Grasshopper binaries inflate client-side into GhXml — no
-						server round-trip for the import path.
-					</p>
-				</div>
+			<section className="mx-auto mt-16 max-w-4xl">
+				<h2 className="mb-4 text-xl font-semibold">Two tools, one product</h2>
+				<ProductContrast emphasis="equal" />
 			</section>
 		</div>
 	);

--- a/src/app/landing/variants/lp2-paste-lab.tsx
+++ b/src/app/landing/variants/lp2-paste-lab.tsx
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useState } from "react";
+import { FileUp, Link2, Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useModifierKeyLabel } from "@/app/hooks/use-modifier-key-label";
+import { PrimarySignUp, SecondaryDuckerLink } from "../ctas";
+
+type Phase = "idle" | "catching" | "validating" | "ready";
+
+export function Lp2PasteLab() {
+	const modifier = useModifierKeyLabel();
+	const [phase, setPhase] = useState<Phase>("idle");
+	const [source, setSource] = useState<"paste" | "drop" | null>(null);
+	const [dragOver, setDragOver] = useState(false);
+	const [flash, setFlash] = useState(false);
+
+	const runImport = useCallback((next: "paste" | "drop") => {
+		setSource(next);
+		setPhase("catching");
+		window.setTimeout(() => setPhase("validating"), 450);
+		window.setTimeout(() => setPhase("ready"), 1100);
+	}, []);
+
+	useEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			const isPaste =
+				(event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "v";
+			if (!isPaste) return;
+			const target = event.target as HTMLElement | null;
+			if (
+				target &&
+				(target.tagName === "INPUT" ||
+					target.tagName === "TEXTAREA" ||
+					target.isContentEditable)
+			) {
+				return;
+			}
+			event.preventDefault();
+			setFlash(true);
+			window.setTimeout(() => setFlash(false), 200);
+			runImport("paste");
+		};
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, [runImport]);
+
+	return (
+		<div className="pb-16">
+			<section className="relative flex min-h-[72vh] flex-col justify-center pt-4">
+				<div
+					aria-hidden
+					className={cn(
+						"pointer-events-none absolute inset-0 transition-opacity duration-500",
+						flash ? "opacity-100" : "opacity-0"
+					)}
+					style={{
+						background:
+							"radial-gradient(ellipse at center, rgba(255,255,255,0.08), transparent 55%)",
+					}}
+				/>
+
+				<div className="relative z-10 mx-auto max-w-3xl text-center">
+					<p className="text-5xl font-bold tracking-tight md:text-7xl">
+						Hopper Clip
+					</p>
+					<h1 className="mt-4 text-2xl font-semibold text-neutral-100 md:text-3xl">
+						Paste a definition. Skip the zip.
+					</h1>
+					<p className="mx-auto mt-4 max-w-xl text-base text-neutral-400 md:text-lg">
+						Native {modifier}+V imports GhXml without clipboard permission
+						prompts. Or drop a{" "}
+						<code className="rounded bg-neutral-800 px-1.5 py-0.5 text-sm">
+							.gh
+						</code>{" "}
+						/{" "}
+						<code className="rounded bg-neutral-800 px-1.5 py-0.5 text-sm">
+							.ghx
+						</code>{" "}
+						file — same pipeline.
+					</p>
+				</div>
+
+				<div
+					className={cn(
+						"relative z-10 mx-auto mt-10 w-full max-w-2xl overflow-hidden rounded-2xl border transition-all duration-300",
+						dragOver
+							? "border-white bg-neutral-900 scale-[1.01]"
+							: "border-neutral-700 bg-neutral-950",
+						phase === "ready" && "border-emerald-500/40"
+					)}
+					onDragEnter={(e) => {
+						e.preventDefault();
+						setDragOver(true);
+					}}
+					onDragOver={(e) => e.preventDefault()}
+					onDragLeave={() => setDragOver(false)}
+					onDrop={(e) => {
+						e.preventDefault();
+						setDragOver(false);
+						runImport("drop");
+					}}
+				>
+					<div className="flex min-h-56 flex-col items-center justify-center gap-4 px-6 py-10 text-center">
+						{phase === "idle" || phase === "catching" ? (
+							<>
+								<div className="flex items-center gap-3 text-neutral-300">
+									<span className="inline-flex items-center gap-2 rounded-md border border-neutral-600 px-3 py-1.5 font-mono text-sm">
+										{modifier}+V
+									</span>
+									<span className="text-neutral-600">or</span>
+									<span className="inline-flex items-center gap-2 rounded-md border border-neutral-600 px-3 py-1.5 text-sm">
+										<FileUp className="h-4 w-4" />
+										Drop .gh
+									</span>
+								</div>
+								<p className="max-w-sm text-sm text-neutral-500">
+									Press {modifier}+V anywhere on this page, click Simulate paste,
+									or drop a file on this zone.
+								</p>
+								<button
+									type="button"
+									onClick={() => runImport("paste")}
+									className="rounded-md bg-white px-4 py-2 text-sm font-semibold text-black transition-colors hover:bg-neutral-200"
+								>
+									Simulate paste
+								</button>
+							</>
+						) : null}
+
+						{phase === "validating" ? (
+							<div className="flex flex-col items-center gap-3">
+								<div className="h-8 w-8 animate-spin rounded-full border-2 border-neutral-600 border-t-white" />
+								<p className="text-sm text-neutral-300">
+									Validating GhXml from {source === "drop" ? "file" : "clipboard"}…
+								</p>
+							</div>
+						) : null}
+
+						{phase === "ready" ? (
+							<div className="flex w-full max-w-md flex-col items-stretch gap-4 animate-in fade-in duration-500">
+								<div className="flex items-start gap-3 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-left">
+									<Sparkles className="mt-0.5 h-4 w-4 text-emerald-300" />
+									<div>
+										<p className="text-sm font-medium text-emerald-100">
+											Definition ready
+										</p>
+										<p className="mt-1 text-xs text-emerald-200/70">
+											Sun path · 12 components · imported via{" "}
+											{source === "drop" ? "file drop" : `${modifier}+V`}
+										</p>
+									</div>
+								</div>
+								<div className="flex items-center justify-between rounded-lg border border-neutral-700 bg-neutral-900 px-4 py-3">
+									<div className="flex items-center gap-2 text-sm text-neutral-300">
+										<Link2 className="h-4 w-4 text-neutral-500" />
+										hopperclip.com/s/sun-path
+									</div>
+									<span className="text-xs text-neutral-500">shareable</span>
+								</div>
+								<button
+									type="button"
+									onClick={() => {
+										setPhase("idle");
+										setSource(null);
+									}}
+									className="text-xs text-neutral-500 underline-offset-2 hover:text-neutral-300 hover:underline"
+								>
+									Reset demo
+								</button>
+							</div>
+						) : null}
+					</div>
+
+					{phase === "catching" ? (
+						<div className="absolute inset-x-0 top-0 h-1 overflow-hidden bg-neutral-800">
+							<div className="h-full w-1/2 animate-pulse bg-white" />
+						</div>
+					) : null}
+				</div>
+
+				<div className="relative z-10 mt-8 flex flex-wrap justify-center gap-3">
+					<PrimarySignUp label="Start clipping" />
+					<SecondaryDuckerLink label="Paste into DuckerWeb" />
+				</div>
+			</section>
+
+			<section className="mx-auto mt-8 grid max-w-3xl gap-6 md:grid-cols-2">
+				<div>
+					<h2 className="text-lg font-semibold">Cards & Diff share the same paste</h2>
+					<p className="mt-2 text-sm text-neutral-400">
+						On /ghcards, paste opens create-card. In DuckerWeb Diff, paste targets
+						the comparison definition. Field pastes stay normal.
+					</p>
+				</div>
+				<div>
+					<h2 className="text-lg font-semibold">Native .gh decoding</h2>
+					<p className="mt-2 text-sm text-neutral-400">
+						Saved Grasshopper binaries inflate client-side into GhXml — no
+						server round-trip for the import path.
+					</p>
+				</div>
+			</section>
+		</div>
+	);
+}

--- a/src/app/landing/variants/lp3-expression-lab.tsx
+++ b/src/app/landing/variants/lp3-expression-lab.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
-import { PrimarySignUp, SecondaryDuckerLink } from "../ctas";
+import { PrimarySignUp, SecondaryDuckerLink, ProductContrast } from "../ctas";
 
 type ExprNode = {
 	id: string;
@@ -65,28 +65,30 @@ export function Lp3ExpressionLab() {
 
 	return (
 		<div className="pb-16">
-			<section className="grid min-h-[72vh] items-center gap-10 pt-6 lg:grid-cols-2">
+			<section className="grid min-h-[68vh] items-center gap-10 pt-6 lg:grid-cols-2">
 				<div>
 					<p className="text-5xl font-bold tracking-tight md:text-6xl">
 						Hopper Clip
 					</p>
 					<h1 className="mt-4 text-2xl font-semibold md:text-3xl">
-						Formulas you can hover, pin, and copy.
+						Save Grasshopper scripts online — inspect what&apos;s inside
+						locally.
 					</h1>
 					<p className="mt-4 max-w-md text-neutral-400 md:text-lg">
-						Expression badges on DuckerWeb nodes open a click-to-pin inspector —
-						no tiny native tooltips. Escape or click outside to dismiss.
+						Hopper Clip is your pastebin: account, tags, shareable links.
+						DuckerWeb is the local-first companion that opens .gh files in the
+						browser so you can read graphs and expressions without uploading.
 					</p>
 					<div className="mt-8 flex flex-wrap gap-3">
 						<PrimarySignUp />
-						<SecondaryDuckerLink label="Inspect in DuckerWeb" />
+						<SecondaryDuckerLink label="Inspect locally" />
 					</div>
 					<p className="mt-6 text-xs text-neutral-600">
-						Tip: hover a{" "}
+						Try the inspector: hover a{" "}
 						<span className="rounded bg-neutral-800 px-1 font-mono text-neutral-300">
 							*
 						</span>{" "}
-						badge, then click to pin.
+						badge, click to pin.
 					</p>
 				</div>
 
@@ -95,6 +97,9 @@ export function Lp3ExpressionLab() {
 					className="relative aspect-square max-h-[420px] w-full overflow-visible rounded-2xl border border-neutral-700 md:aspect-[5/4]"
 					style={{ backgroundColor: "#ccc9c0" }}
 				>
+					<p className="absolute top-3 left-3 z-10 rounded bg-black/60 px-2 py-1 text-[10px] tracking-wide text-neutral-300 uppercase">
+						DuckerWeb · local canvas
+					</p>
 					<div
 						aria-hidden
 						className="absolute inset-0 rounded-2xl"
@@ -171,7 +176,7 @@ export function Lp3ExpressionLab() {
 										<p className="text-[10px] tracking-wide text-neutral-500 uppercase">
 											{pinned === node.id ? "Pinned expression" : "Expression"}
 										</p>
-										<p className="mt-1 select-text font-mono text-xs leading-relaxed text-amber-100 break-words">
+										<p className="mt-1 font-mono text-xs leading-relaxed break-words text-amber-100 select-text">
 											{node.expression}
 										</p>
 										{pinned === node.id ? (
@@ -187,13 +192,17 @@ export function Lp3ExpressionLab() {
 				</div>
 			</section>
 
-			<section className="mt-12 max-w-2xl">
-				<h2 className="text-xl font-semibold">Built for reading logic, not guessing</h2>
-				<p className="mt-2 text-neutral-400">
-					Component-level expressions and internal expressions surface on flow
-					nodes — not buried only inside folded port options. Pair with Diff to
-					see when a formula actually changed.
-				</p>
+			<section className="mt-16">
+				<h2 className="mb-4 text-xl font-semibold">Two tools, one product</h2>
+				<ProductContrast emphasis="ducker" />
+				{active ? (
+					<p className="mt-4 text-sm text-neutral-500">
+						Active demo formula:{" "}
+						<span className="font-mono text-neutral-300">
+							{active.expression}
+						</span>
+					</p>
+				) : null}
 			</section>
 		</div>
 	);

--- a/src/app/landing/variants/lp3-expression-lab.tsx
+++ b/src/app/landing/variants/lp3-expression-lab.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import { PrimarySignUp, SecondaryDuckerLink } from "../ctas";
+
+type ExprNode = {
+	id: string;
+	label: string;
+	x: number;
+	y: number;
+	kind: "component" | "value";
+	expression?: string;
+};
+
+const NODES: ExprNode[] = [
+	{
+		id: "n1",
+		label: "Number",
+		x: 18,
+		y: 35,
+		kind: "value",
+		expression: "x * 2 + 1",
+	},
+	{
+		id: "n2",
+		label: "Expression",
+		x: 48,
+		y: 50,
+		kind: "component",
+		expression: "Sin(t) * Radius",
+	},
+	{
+		id: "n3",
+		label: "Move",
+		x: 78,
+		y: 35,
+		kind: "component",
+		expression: "UnitZ * Height",
+	},
+];
+
+export function Lp3ExpressionLab() {
+	const [hovered, setHovered] = useState<string | null>(null);
+	const [pinned, setPinned] = useState<string | null>(null);
+	const stageRef = useRef<HTMLDivElement>(null);
+
+	const activeId = pinned ?? hovered;
+	const active = NODES.find((n) => n.id === activeId);
+
+	useEffect(() => {
+		const onKey = (event: KeyboardEvent) => {
+			if (event.key === "Escape") setPinned(null);
+		};
+		const onPointer = (event: MouseEvent) => {
+			if (!stageRef.current?.contains(event.target as Node)) {
+				setPinned(null);
+			}
+		};
+		window.addEventListener("keydown", onKey);
+		window.addEventListener("mousedown", onPointer);
+		return () => {
+			window.removeEventListener("keydown", onKey);
+			window.removeEventListener("mousedown", onPointer);
+		};
+	}, []);
+
+	return (
+		<div className="pb-16">
+			<section className="grid min-h-[72vh] items-center gap-10 pt-6 lg:grid-cols-2">
+				<div>
+					<p className="text-5xl font-bold tracking-tight md:text-6xl">
+						Hopper Clip
+					</p>
+					<h1 className="mt-4 text-2xl font-semibold md:text-3xl">
+						Formulas you can hover, pin, and copy.
+					</h1>
+					<p className="mt-4 max-w-md text-neutral-400 md:text-lg">
+						Expression badges on DuckerWeb nodes open a click-to-pin inspector —
+						no tiny native tooltips. Escape or click outside to dismiss.
+					</p>
+					<div className="mt-8 flex flex-wrap gap-3">
+						<PrimarySignUp />
+						<SecondaryDuckerLink label="Inspect in DuckerWeb" />
+					</div>
+					<p className="mt-6 text-xs text-neutral-600">
+						Tip: hover a{" "}
+						<span className="rounded bg-neutral-800 px-1 font-mono text-neutral-300">
+							*
+						</span>{" "}
+						badge, then click to pin.
+					</p>
+				</div>
+
+				<div
+					ref={stageRef}
+					className="relative aspect-square max-h-[420px] w-full overflow-visible rounded-2xl border border-neutral-700 md:aspect-[5/4]"
+					style={{ backgroundColor: "#ccc9c0" }}
+				>
+					<div
+						aria-hidden
+						className="absolute inset-0 rounded-2xl"
+						style={{
+							backgroundImage:
+								"linear-gradient(#bbb8af 1px, transparent 1px), linear-gradient(90deg, #bbb8af 1px, transparent 1px)",
+							backgroundSize: "28px 28px",
+						}}
+					/>
+
+					<svg className="absolute inset-0 h-full w-full" aria-hidden>
+						<path
+							d="M 22% 38% C 34% 38%, 34% 52%, 46% 52%"
+							fill="none"
+							stroke="#5a5a5a"
+							strokeWidth="2"
+						/>
+						<path
+							d="M 56% 52% C 66% 52%, 66% 38%, 76% 38%"
+							fill="none"
+							stroke="#5a5a5a"
+							strokeWidth="2"
+						/>
+					</svg>
+
+					{NODES.map((node) => {
+						const showBadge = Boolean(node.expression);
+						const isLive = activeId === node.id;
+						return (
+							<div
+								key={node.id}
+								className="absolute -translate-x-1/2 -translate-y-1/2"
+								style={{ left: `${node.x}%`, top: `${node.y}%` }}
+							>
+								<div
+									className={cn(
+										"relative rounded-sm px-3 py-2 text-xs font-medium text-neutral-900 shadow-sm transition-transform",
+										node.kind === "value" ? "bg-[#f5f07a]" : "bg-[#b8b5ae]",
+										isLive && "scale-105"
+									)}
+								>
+									{node.label}
+									{showBadge ? (
+										<button
+											type="button"
+											aria-label={`Inspect expression on ${node.label}`}
+											className={cn(
+												"absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full bg-neutral-900 font-mono text-[10px] text-amber-300 ring-1 ring-amber-400/50 transition-transform hover:scale-110",
+												isLive && "bg-amber-400 text-neutral-900"
+											)}
+											onMouseEnter={() => setHovered(node.id)}
+											onMouseLeave={() => setHovered(null)}
+											onClick={(e) => {
+												e.stopPropagation();
+												setPinned((prev) =>
+													prev === node.id ? null : node.id
+												);
+											}}
+										>
+											*
+										</button>
+									) : null}
+								</div>
+
+								{isLive && node.expression ? (
+									<div
+										className={cn(
+											"absolute top-[calc(100%+10px)] left-1/2 z-20 w-48 -translate-x-1/2 rounded-md border border-neutral-600 bg-neutral-950 p-3 text-left shadow-xl",
+											pinned === node.id && "ring-1 ring-amber-400/40"
+										)}
+										onMouseEnter={() => setHovered(node.id)}
+										onMouseLeave={() => setHovered(null)}
+									>
+										<p className="text-[10px] tracking-wide text-neutral-500 uppercase">
+											{pinned === node.id ? "Pinned expression" : "Expression"}
+										</p>
+										<p className="mt-1 select-text font-mono text-xs leading-relaxed text-amber-100 break-words">
+											{node.expression}
+										</p>
+										{pinned === node.id ? (
+											<p className="mt-2 text-[10px] text-neutral-500">
+												Esc / outside click to close
+											</p>
+										) : null}
+									</div>
+								) : null}
+							</div>
+						);
+					})}
+				</div>
+			</section>
+
+			<section className="mt-12 max-w-2xl">
+				<h2 className="text-xl font-semibold">Built for reading logic, not guessing</h2>
+				<p className="mt-2 text-neutral-400">
+					Component-level expressions and internal expressions surface on flow
+					nodes — not buried only inside folded port options. Pair with Diff to
+					see when a formula actually changed.
+				</p>
+			</section>
+		</div>
+	);
+}

--- a/src/app/landing/variants/lp4-split-story.tsx
+++ b/src/app/landing/variants/lp4-split-story.tsx
@@ -1,0 +1,141 @@
+import { useState } from "react";
+import { GitCompareArrows, Share2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { PrimarySignUp, SecondaryDuckerLink } from "../ctas";
+
+export function Lp4SplitStory() {
+	const [balance, setBalance] = useState(50);
+	const [hoverSide, setHoverSide] = useState<"clip" | "ducker" | null>(null);
+
+	const clipFlex = hoverSide === "clip" ? 1.35 : hoverSide === "ducker" ? 0.75 : 1;
+	const duckerFlex =
+		hoverSide === "ducker" ? 1.35 : hoverSide === "clip" ? 0.75 : 1;
+
+	return (
+		<div className="pb-16">
+			<section className="pt-4 text-center">
+				<p className="text-5xl font-bold tracking-tight md:text-7xl">
+					Hopper Clip
+				</p>
+				<h1 className="mx-auto mt-4 max-w-2xl text-2xl font-semibold text-neutral-100 md:text-3xl">
+					One place to share definitions. One canvas to prove what changed.
+				</h1>
+				<p className="mx-auto mt-4 max-w-xl text-neutral-400">
+					Drag the split — or hover a side — to weigh Clip sharing against
+					DuckerWeb Diff. Same GhXml, two jobs.
+				</p>
+				<div className="mt-8 flex flex-wrap justify-center gap-3">
+					<PrimarySignUp />
+					<SecondaryDuckerLink />
+				</div>
+			</section>
+
+			<section className="mt-12">
+				<div className="mb-4 flex items-center gap-3">
+					<span className="w-16 text-right text-xs text-neutral-500">Clip</span>
+					<input
+						type="range"
+						min={20}
+						max={80}
+						value={balance}
+						onChange={(e) => setBalance(Number(e.target.value))}
+						className="h-1.5 flex-1 cursor-ew-resize appearance-none rounded-full bg-neutral-800 accent-white"
+						aria-label="Balance between Hopper Clip and DuckerWeb"
+					/>
+					<span className="w-16 text-xs text-neutral-500">Ducker</span>
+				</div>
+
+				<div className="flex min-h-[340px] flex-col gap-3 md:flex-row">
+					<article
+						onMouseEnter={() => setHoverSide("clip")}
+						onMouseLeave={() => setHoverSide(null)}
+						style={{ flex: clipFlex * (100 - balance) }}
+						className="relative flex min-h-64 flex-col justify-between overflow-hidden rounded-2xl border border-neutral-700 bg-neutral-950 p-6 transition-[flex] duration-500 ease-out"
+					>
+						<div
+							aria-hidden
+							className="pointer-events-none absolute -right-8 -bottom-10 h-40 w-40 rounded-full bg-white/5 blur-2xl"
+						/>
+						<div>
+							<div className="mb-4 inline-flex items-center gap-2 text-neutral-300">
+								<Share2 className="h-4 w-4" />
+								<span className="text-sm font-medium">Hopper Clip</span>
+							</div>
+							<h2 className="text-xl font-semibold">Share with a link</h2>
+							<p className="mt-2 text-sm leading-relaxed text-neutral-400">
+								Drop{" "}
+								<code className="rounded bg-neutral-800 px-1">.gh</code> / paste
+								GhXml, tag it, and send a short URL. Recipients inspect in the
+								browser and copy the XML back out.
+							</p>
+						</div>
+						<ul className="mt-6 space-y-2 text-sm text-neutral-300">
+							<li className="flex gap-2">
+								<span className="text-neutral-600">01</span>
+								Native paste & file import
+							</li>
+							<li className="flex gap-2">
+								<span className="text-neutral-600">02</span>
+								Tags, search, your library
+							</li>
+							<li className="flex gap-2">
+								<span className="text-neutral-600">03</span>
+								Public share cards
+							</li>
+						</ul>
+					</article>
+
+					<article
+						onMouseEnter={() => setHoverSide("ducker")}
+						onMouseLeave={() => setHoverSide(null)}
+						style={{
+							flex: duckerFlex * balance,
+							backgroundColor: "#1a1916",
+							backgroundImage:
+								"linear-gradient(rgba(187,184,175,0.08) 1px, transparent 1px), linear-gradient(90deg, rgba(187,184,175,0.08) 1px, transparent 1px)",
+							backgroundSize: "24px 24px",
+						}}
+						className={cn(
+							"relative flex min-h-64 flex-col justify-between overflow-hidden rounded-2xl border border-neutral-700 p-6 transition-[flex] duration-500 ease-out"
+						)}
+					>
+						<div>
+							<div className="mb-4 inline-flex items-center gap-2 text-neutral-300">
+								<GitCompareArrows className="h-4 w-4" />
+								<span className="text-sm font-medium">DuckerWeb</span>
+							</div>
+							<h2 className="text-xl font-semibold">Diff the logic</h2>
+							<p className="mt-2 text-sm leading-relaxed text-neutral-400">
+								Load original, paste the changed file, scan green / yellow /
+								red. Port mapping, expressions, and wires get plain-language
+								summaries.
+							</p>
+						</div>
+						<div className="mt-6 flex flex-wrap gap-2 text-[11px] font-medium">
+							<span className="rounded-md bg-green-500/15 px-2 py-1 text-green-300 ring-1 ring-green-500/30">
+								Added
+							</span>
+							<span className="rounded-md bg-yellow-400/15 px-2 py-1 text-yellow-200 ring-1 ring-yellow-400/30">
+								Modified
+							</span>
+							<span className="rounded-md bg-red-500/15 px-2 py-1 text-red-300 ring-1 ring-red-500/30">
+								Removed
+							</span>
+							<span className="rounded-md bg-neutral-800 px-2 py-1 text-neutral-400 ring-1 ring-neutral-600">
+								Layout moves ignored
+							</span>
+						</div>
+					</article>
+				</div>
+			</section>
+
+			<section className="mx-auto mt-14 max-w-2xl text-center">
+				<h2 className="text-xl font-semibold">Inspect expressions while you compare</h2>
+				<p className="mt-2 text-neutral-400">
+					Hover the * badge on a node, pin the formula, copy it — then jump back
+					to the Diff rail for port-level change copy.
+				</p>
+			</section>
+		</div>
+	);
+}

--- a/src/app/landing/variants/lp4-split-story.tsx
+++ b/src/app/landing/variants/lp4-split-story.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import { GitCompareArrows, Share2 } from "lucide-react";
-import { cn } from "@/lib/utils";
-import { PrimarySignUp, SecondaryDuckerLink } from "../ctas";
+import { PrimarySignUp, SecondaryDuckerLink, ProductContrast } from "../ctas";
 
 export function Lp4SplitStory() {
 	const [balance, setBalance] = useState(50);
 	const [hoverSide, setHoverSide] = useState<"clip" | "ducker" | null>(null);
 
-	const clipFlex = hoverSide === "clip" ? 1.35 : hoverSide === "ducker" ? 0.75 : 1;
+	const clipFlex =
+		hoverSide === "clip" ? 1.35 : hoverSide === "ducker" ? 0.75 : 1;
 	const duckerFlex =
 		hoverSide === "ducker" ? 1.35 : hoverSide === "clip" ? 0.75 : 1;
 
@@ -18,11 +18,12 @@ export function Lp4SplitStory() {
 					Hopper Clip
 				</p>
 				<h1 className="mx-auto mt-4 max-w-2xl text-2xl font-semibold text-neutral-100 md:text-3xl">
-					One place to share definitions. One canvas to prove what changed.
+					Online pastebin for Grasshopper — with a local-first file inspector.
 				</h1>
 				<p className="mx-auto mt-4 max-w-xl text-neutral-400">
-					Drag the split — or hover a side — to weigh Clip sharing against
-					DuckerWeb Diff. Same GhXml, two jobs.
+					Drag the split (or hover a side) to see the difference: Clip saves and
+					shares online; DuckerWeb opens .gh files in your browser without
+					uploading.
 				</p>
 				<div className="mt-8 flex flex-wrap justify-center gap-3">
 					<PrimarySignUp />
@@ -32,7 +33,9 @@ export function Lp4SplitStory() {
 
 			<section className="mt-12">
 				<div className="mb-4 flex items-center gap-3">
-					<span className="w-16 text-right text-xs text-neutral-500">Clip</span>
+					<span className="w-16 text-right text-xs text-neutral-500">
+						Online
+					</span>
 					<input
 						type="range"
 						min={20}
@@ -42,7 +45,7 @@ export function Lp4SplitStory() {
 						className="h-1.5 flex-1 cursor-ew-resize appearance-none rounded-full bg-neutral-800 accent-white"
 						aria-label="Balance between Hopper Clip and DuckerWeb"
 					/>
-					<span className="w-16 text-xs text-neutral-500">Ducker</span>
+					<span className="w-16 text-xs text-neutral-500">Local</span>
 				</div>
 
 				<div className="flex min-h-[340px] flex-col gap-3 md:flex-row">
@@ -50,37 +53,38 @@ export function Lp4SplitStory() {
 						onMouseEnter={() => setHoverSide("clip")}
 						onMouseLeave={() => setHoverSide(null)}
 						style={{ flex: clipFlex * (100 - balance) }}
-						className="relative flex min-h-64 flex-col justify-between overflow-hidden rounded-2xl border border-neutral-700 bg-neutral-950 p-6 transition-[flex] duration-500 ease-out"
+						className="relative flex min-h-64 flex-col justify-between overflow-hidden rounded-2xl border border-neutral-600 bg-neutral-950 p-6 transition-[flex] duration-500 ease-out"
 					>
 						<div
 							aria-hidden
 							className="pointer-events-none absolute -right-8 -bottom-10 h-40 w-40 rounded-full bg-white/5 blur-2xl"
 						/>
 						<div>
-							<div className="mb-4 inline-flex items-center gap-2 text-neutral-300">
+							<p className="mb-1 text-[11px] tracking-[0.16em] text-emerald-400/80 uppercase">
+								Main product · online
+							</p>
+							<div className="mb-4 inline-flex items-center gap-2 text-neutral-200">
 								<Share2 className="h-4 w-4" />
 								<span className="text-sm font-medium">Hopper Clip</span>
 							</div>
-							<h2 className="text-xl font-semibold">Share with a link</h2>
+							<h2 className="text-xl font-semibold">Pastebin for GH scripts</h2>
 							<p className="mt-2 text-sm leading-relaxed text-neutral-400">
-								Drop{" "}
-								<code className="rounded bg-neutral-800 px-1">.gh</code> / paste
-								GhXml, tag it, and send a short URL. Recipients inspect in the
-								browser and copy the XML back out.
+								Save definitions to your account, organize with tags, and share
+								a link — so scripts live online instead of in file attachments.
 							</p>
 						</div>
 						<ul className="mt-6 space-y-2 text-sm text-neutral-300">
 							<li className="flex gap-2">
 								<span className="text-neutral-600">01</span>
-								Native paste & file import
+								Paste or drop → save to your library
 							</li>
 							<li className="flex gap-2">
 								<span className="text-neutral-600">02</span>
-								Tags, search, your library
+								Tag, search, revisit later
 							</li>
 							<li className="flex gap-2">
 								<span className="text-neutral-600">03</span>
-								Public share cards
+								Send a short share URL
 							</li>
 						</ul>
 					</article>
@@ -95,20 +99,21 @@ export function Lp4SplitStory() {
 								"linear-gradient(rgba(187,184,175,0.08) 1px, transparent 1px), linear-gradient(90deg, rgba(187,184,175,0.08) 1px, transparent 1px)",
 							backgroundSize: "24px 24px",
 						}}
-						className={cn(
-							"relative flex min-h-64 flex-col justify-between overflow-hidden rounded-2xl border border-neutral-700 p-6 transition-[flex] duration-500 ease-out"
-						)}
+						className="relative flex min-h-64 flex-col justify-between overflow-hidden rounded-2xl border border-neutral-600 p-6 transition-[flex] duration-500 ease-out"
 					>
 						<div>
-							<div className="mb-4 inline-flex items-center gap-2 text-neutral-300">
+							<p className="mb-1 text-[11px] tracking-[0.16em] text-sky-400/80 uppercase">
+								Companion tool · local-first
+							</p>
+							<div className="mb-4 inline-flex items-center gap-2 text-neutral-200">
 								<GitCompareArrows className="h-4 w-4" />
 								<span className="text-sm font-medium">DuckerWeb</span>
 							</div>
-							<h2 className="text-xl font-semibold">Diff the logic</h2>
+							<h2 className="text-xl font-semibold">Look inside .gh files</h2>
 							<p className="mt-2 text-sm leading-relaxed text-neutral-400">
-								Load original, paste the changed file, scan green / yellow /
-								red. Port mapping, expressions, and wires get plain-language
-								summaries.
+								Open a file in your browser to see the graph, Diff two versions,
+								and inspect expressions — nothing is uploaded unless you choose
+								to save a card.
 							</p>
 						</div>
 						<div className="mt-6 flex flex-wrap gap-2 text-[11px] font-medium">
@@ -122,19 +127,18 @@ export function Lp4SplitStory() {
 								Removed
 							</span>
 							<span className="rounded-md bg-neutral-800 px-2 py-1 text-neutral-400 ring-1 ring-neutral-600">
-								Layout moves ignored
+								No upload required
 							</span>
 						</div>
 					</article>
 				</div>
 			</section>
 
-			<section className="mx-auto mt-14 max-w-2xl text-center">
-				<h2 className="text-xl font-semibold">Inspect expressions while you compare</h2>
-				<p className="mt-2 text-neutral-400">
-					Hover the * badge on a node, pin the formula, copy it — then jump back
-					to the Diff rail for port-level change copy.
-				</p>
+			<section className="mx-auto mt-14 max-w-4xl">
+				<h2 className="mb-4 text-center text-xl font-semibold">
+					Same product, different jobs
+				</h2>
+				<ProductContrast emphasis="equal" />
 			</section>
 		</div>
 	);

--- a/src/app/landing/variants/lp5-product-tour.tsx
+++ b/src/app/landing/variants/lp5-product-tour.tsx
@@ -5,25 +5,45 @@ import {
 	GitCompareArrows,
 	Asterisk,
 	Share2,
+	Cloud,
+	HardDrive,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useModifierKeyLabel } from "@/app/hooks/use-modifier-key-label";
-import { PrimarySignUp, SecondaryDuckerLink } from "../ctas";
+import { PrimarySignUp, SecondaryDuckerLink, ProductContrast } from "../ctas";
 
 const STEPS = [
+	{
+		id: "what",
+		title: "What it is",
+		icon: Share2,
+		headline: "A pastebin for Grasshopper scripts",
+		body: "Hopper Clip is the main product: save definitions to your account, organize with tags, and share a link — online, like a snippet manager for GH.",
+		where: "online" as const,
+	},
 	{
 		id: "import",
 		title: "Import",
 		icon: FileUp,
 		headline: "Drop .gh or paste GhXml",
-		body: "Native binary .gh decoding and clipboard paste feed the same validation path — cards and DuckerWeb alike.",
+		body: "Native binary .gh decoding and clipboard paste feed the same validation path — whether you're about to save a card or just peek locally.",
+		where: "both" as const,
 	},
 	{
 		id: "share",
-		title: "Share",
-		icon: Share2,
+		title: "Save & share",
+		icon: Cloud,
 		headline: "Ship a link, not a zip",
-		body: "Tag it, save it, send a short URL. Recipients open the definition in-browser and copy XML when they need it.",
+		body: "Once saved, send a short URL. Recipients open the definition in-browser and copy XML when they need it. That's the pastebin job.",
+		where: "online" as const,
+	},
+	{
+		id: "ducker",
+		title: "DuckerWeb",
+		icon: HardDrive,
+		headline: "Local-first .gh inspector",
+		body: "Don't want to upload yet? Open the file in DuckerWeb: browse the graph, Diff two versions, inspect expressions — stays in your browser.",
+		where: "local" as const,
 	},
 	{
 		id: "diff",
@@ -31,13 +51,15 @@ const STEPS = [
 		icon: GitCompareArrows,
 		headline: "Compare logic, not layout",
 		body: "Match by instance GUID. Overlay added / modified / removed. Port changes get readable summaries; layout-only moves stay quiet.",
+		where: "local" as const,
 	},
 	{
 		id: "inspect",
 		title: "Inspect",
 		icon: Asterisk,
 		headline: "Pin the expression",
-		body: "Hover the * badge, click to pin, select and copy the formula. Escape dismisses — built for reading, not guessing.",
+		body: "Hover the * badge, click to pin, select and copy the formula. Escape dismisses — built for reading what's inside the file.",
+		where: "local" as const,
 	},
 ] as const;
 
@@ -64,10 +86,11 @@ export function Lp5ProductTour() {
 					Hopper Clip
 				</p>
 				<h1 className="mx-auto mt-4 max-w-2xl text-2xl font-semibold md:text-3xl">
-					From clipboard to Diff in four beats.
+					Pastebin online. Inspector local. Same Grasshopper files.
 				</h1>
 				<p className="mx-auto mt-3 max-w-lg text-neutral-400">
-					A guided tour of what just shipped — pause anytime and click a step.
+					Walk through what the product is — then the new Diff, paste, and
+					inspect features. Pause anytime and click a step.
 				</p>
 			</section>
 
@@ -122,18 +145,31 @@ export function Lp5ProductTour() {
 
 					<div className="grid gap-0 md:grid-cols-2">
 						<div className="flex flex-col justify-center p-8 md:p-10">
-							<p className="font-mono text-xs text-neutral-500">
-								Step {step + 1} / {STEPS.length}
-							</p>
-							<h2 className="mt-3 text-2xl font-semibold">{current.headline}</h2>
+							<div className="flex items-center gap-2">
+								<p className="font-mono text-xs text-neutral-500">
+									Step {step + 1} / {STEPS.length}
+								</p>
+								{current.where === "online" ? (
+									<span className="rounded bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-300 ring-1 ring-emerald-500/30">
+										Online
+									</span>
+								) : current.where === "local" ? (
+									<span className="rounded bg-sky-500/15 px-2 py-0.5 text-[10px] font-medium text-sky-300 ring-1 ring-sky-500/30">
+										Local-first
+									</span>
+								) : (
+									<span className="rounded bg-neutral-800 px-2 py-0.5 text-[10px] font-medium text-neutral-400 ring-1 ring-neutral-600">
+										Both
+									</span>
+								)}
+							</div>
+							<h2 className="mt-3 text-2xl font-semibold">
+								{current.headline}
+							</h2>
 							<p className="mt-3 text-neutral-400">{current.body}</p>
 							<div className="mt-8 flex flex-wrap gap-3">
 								<PrimarySignUp label="Get Started Free" />
-								{current.id === "diff" || current.id === "inspect" ? (
-									<SecondaryDuckerLink />
-								) : (
-									<SecondaryDuckerLink label="Open DuckerWeb" />
-								)}
+								<SecondaryDuckerLink />
 							</div>
 						</div>
 
@@ -143,21 +179,34 @@ export function Lp5ProductTour() {
 					</div>
 				</div>
 			</section>
+
+			<section className="mx-auto mt-14 max-w-4xl">
+				<h2 className="mb-4 text-center text-xl font-semibold">
+					Remember the split
+				</h2>
+				<ProductContrast emphasis="equal" />
+			</section>
 		</div>
 	);
 }
 
-function StepStage({
-	stepId,
-	modifier,
-}: {
-	stepId: StepId;
-	modifier: string;
-}) {
+function StepStage({ stepId, modifier }: { stepId: StepId; modifier: string }) {
+	if (stepId === "what") {
+		return (
+			<div className="flex h-full min-h-64 flex-col items-center justify-center gap-4 bg-neutral-900 p-8">
+				<p className="text-3xl font-bold">Hopper Clip</p>
+				<p className="max-w-xs text-center text-sm text-neutral-400">
+					Think GitHub Gist — but for Grasshopper definitions you actually use
+					in Rhino.
+				</p>
+			</div>
+		);
+	}
+
 	if (stepId === "import") {
 		return (
 			<div className="flex h-full min-h-64 flex-col items-center justify-center gap-4 bg-[#141412] p-8">
-				<div className="flex items-center gap-3">
+				<div className="flex flex-wrap items-center justify-center gap-3">
 					<span className="inline-flex items-center gap-2 rounded-md border border-neutral-600 px-3 py-2 font-mono text-sm text-neutral-200">
 						<ClipboardPaste className="h-4 w-4" />
 						{modifier}+V
@@ -178,14 +227,43 @@ function StepStage({
 	if (stepId === "share") {
 		return (
 			<div className="flex h-full min-h-64 flex-col items-center justify-center gap-3 bg-neutral-900 p-8">
-				<div className="w-full max-w-xs rounded-lg border border-neutral-700 bg-black px-4 py-3">
-					<p className="text-sm font-medium">Sun path utility</p>
+				<div className="w-full max-w-xs rounded-lg border border-emerald-500/30 bg-black px-4 py-3">
+					<p className="text-[10px] tracking-wide text-emerald-400/80 uppercase">
+						Saved online
+					</p>
+					<p className="mt-1 text-sm font-medium">Sun path utility</p>
 					<p className="mt-1 text-xs text-neutral-500">#solar · #analysis</p>
 					<p className="mt-3 font-mono text-xs text-neutral-400">
 						hopperclip.com/s/a7k2
 					</p>
 				</div>
-				<p className="text-xs text-neutral-500">Shareable in one click</p>
+			</div>
+		);
+	}
+
+	if (stepId === "ducker") {
+		return (
+			<div
+				className="relative flex h-full min-h-64 flex-col items-center justify-center gap-3 p-6"
+				style={{ backgroundColor: "#ccc9c0" }}
+			>
+				<p className="absolute top-3 left-3 rounded bg-black/60 px-2 py-1 text-[10px] text-sky-200 uppercase">
+					Stays in browser
+				</p>
+				<div className="flex gap-3">
+					<div className="rounded-sm bg-[#b8b5ae] px-3 py-2 text-xs text-neutral-900">
+						Point
+					</div>
+					<div className="rounded-sm bg-[#f5f07a] px-3 py-2 text-xs text-neutral-900">
+						Number
+					</div>
+					<div className="rounded-sm bg-[#b8b5ae] px-3 py-2 text-xs text-neutral-900">
+						Move
+					</div>
+				</div>
+				<p className="text-xs text-neutral-700">
+					Graph · list · Diff · inspect
+				</p>
 			</div>
 		);
 	}
@@ -237,7 +315,9 @@ function StepStage({
 				</span>
 			</div>
 			<div className="absolute top-1/2 left-1/2 mt-10 w-52 -translate-x-1/2 rounded-md border border-neutral-600 bg-neutral-950 p-3 shadow-xl">
-				<p className="text-[10px] text-neutral-500 uppercase">Pinned expression</p>
+				<p className="text-[10px] text-neutral-500 uppercase">
+					Pinned expression
+				</p>
 				<p className="mt-1 font-mono text-xs text-amber-100">Sin(t) * Radius</p>
 			</div>
 		</div>

--- a/src/app/landing/variants/lp5-product-tour.tsx
+++ b/src/app/landing/variants/lp5-product-tour.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useState } from "react";
+import {
+	ClipboardPaste,
+	FileUp,
+	GitCompareArrows,
+	Asterisk,
+	Share2,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useModifierKeyLabel } from "@/app/hooks/use-modifier-key-label";
+import { PrimarySignUp, SecondaryDuckerLink } from "../ctas";
+
+const STEPS = [
+	{
+		id: "import",
+		title: "Import",
+		icon: FileUp,
+		headline: "Drop .gh or paste GhXml",
+		body: "Native binary .gh decoding and clipboard paste feed the same validation path — cards and DuckerWeb alike.",
+	},
+	{
+		id: "share",
+		title: "Share",
+		icon: Share2,
+		headline: "Ship a link, not a zip",
+		body: "Tag it, save it, send a short URL. Recipients open the definition in-browser and copy XML when they need it.",
+	},
+	{
+		id: "diff",
+		title: "Diff",
+		icon: GitCompareArrows,
+		headline: "Compare logic, not layout",
+		body: "Match by instance GUID. Overlay added / modified / removed. Port changes get readable summaries; layout-only moves stay quiet.",
+	},
+	{
+		id: "inspect",
+		title: "Inspect",
+		icon: Asterisk,
+		headline: "Pin the expression",
+		body: "Hover the * badge, click to pin, select and copy the formula. Escape dismisses — built for reading, not guessing.",
+	},
+] as const;
+
+type StepId = (typeof STEPS)[number]["id"];
+
+export function Lp5ProductTour() {
+	const modifier = useModifierKeyLabel();
+	const [step, setStep] = useState(0);
+	const [auto, setAuto] = useState(true);
+	const current = STEPS[step]!;
+
+	useEffect(() => {
+		if (!auto) return;
+		const id = window.setInterval(() => {
+			setStep((s) => (s + 1) % STEPS.length);
+		}, 3800);
+		return () => window.clearInterval(id);
+	}, [auto]);
+
+	return (
+		<div className="pb-16">
+			<section className="pt-4 text-center">
+				<p className="text-5xl font-bold tracking-tight md:text-6xl">
+					Hopper Clip
+				</p>
+				<h1 className="mx-auto mt-4 max-w-2xl text-2xl font-semibold md:text-3xl">
+					From clipboard to Diff in four beats.
+				</h1>
+				<p className="mx-auto mt-3 max-w-lg text-neutral-400">
+					A guided tour of what just shipped — pause anytime and click a step.
+				</p>
+			</section>
+
+			<section className="mx-auto mt-10 max-w-4xl">
+				<div className="mb-6 flex flex-wrap items-center justify-center gap-2">
+					{STEPS.map((s, index) => {
+						const Icon = s.icon;
+						const active = index === step;
+						return (
+							<button
+								key={s.id}
+								type="button"
+								onClick={() => {
+									setAuto(false);
+									setStep(index);
+								}}
+								className={cn(
+									"inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm transition-all",
+									active
+										? "bg-white text-black"
+										: "bg-neutral-900 text-neutral-400 hover:bg-neutral-800 hover:text-white"
+								)}
+							>
+								<Icon className="h-3.5 w-3.5" />
+								{s.title}
+							</button>
+						);
+					})}
+					<button
+						type="button"
+						onClick={() => setAuto((v) => !v)}
+						className="ml-2 text-xs text-neutral-600 underline-offset-2 hover:text-neutral-400 hover:underline"
+					>
+						{auto ? "Pause" : "Autoplay"}
+					</button>
+				</div>
+
+				<div className="relative overflow-hidden rounded-2xl border border-neutral-700 bg-neutral-950">
+					<div
+						className="absolute inset-x-0 top-0 h-0.5 bg-neutral-800"
+						aria-hidden
+					>
+						<div
+							key={`${current.id}-${auto}`}
+							className={cn(
+								"h-full bg-white",
+								auto && "animate-[tourProgress_3.8s_linear]"
+							)}
+							style={auto ? undefined : { width: "100%" }}
+						/>
+					</div>
+
+					<div className="grid gap-0 md:grid-cols-2">
+						<div className="flex flex-col justify-center p-8 md:p-10">
+							<p className="font-mono text-xs text-neutral-500">
+								Step {step + 1} / {STEPS.length}
+							</p>
+							<h2 className="mt-3 text-2xl font-semibold">{current.headline}</h2>
+							<p className="mt-3 text-neutral-400">{current.body}</p>
+							<div className="mt-8 flex flex-wrap gap-3">
+								<PrimarySignUp label="Get Started Free" />
+								{current.id === "diff" || current.id === "inspect" ? (
+									<SecondaryDuckerLink />
+								) : (
+									<SecondaryDuckerLink label="Open DuckerWeb" />
+								)}
+							</div>
+						</div>
+
+						<div className="relative min-h-64 border-t border-neutral-800 md:border-t-0 md:border-l">
+							<StepStage stepId={current.id} modifier={modifier} />
+						</div>
+					</div>
+				</div>
+			</section>
+		</div>
+	);
+}
+
+function StepStage({
+	stepId,
+	modifier,
+}: {
+	stepId: StepId;
+	modifier: string;
+}) {
+	if (stepId === "import") {
+		return (
+			<div className="flex h-full min-h-64 flex-col items-center justify-center gap-4 bg-[#141412] p-8">
+				<div className="flex items-center gap-3">
+					<span className="inline-flex items-center gap-2 rounded-md border border-neutral-600 px-3 py-2 font-mono text-sm text-neutral-200">
+						<ClipboardPaste className="h-4 w-4" />
+						{modifier}+V
+					</span>
+					<span className="text-neutral-600">/</span>
+					<span className="inline-flex items-center gap-2 rounded-md border border-dashed border-neutral-500 px-3 py-2 text-sm text-neutral-300">
+						<FileUp className="h-4 w-4" />
+						.gh · .ghx
+					</span>
+				</div>
+				<p className="text-center text-xs text-neutral-500">
+					No permission prompt · client-side decode
+				</p>
+			</div>
+		);
+	}
+
+	if (stepId === "share") {
+		return (
+			<div className="flex h-full min-h-64 flex-col items-center justify-center gap-3 bg-neutral-900 p-8">
+				<div className="w-full max-w-xs rounded-lg border border-neutral-700 bg-black px-4 py-3">
+					<p className="text-sm font-medium">Sun path utility</p>
+					<p className="mt-1 text-xs text-neutral-500">#solar · #analysis</p>
+					<p className="mt-3 font-mono text-xs text-neutral-400">
+						hopperclip.com/s/a7k2
+					</p>
+				</div>
+				<p className="text-xs text-neutral-500">Shareable in one click</p>
+			</div>
+		);
+	}
+
+	if (stepId === "diff") {
+		return (
+			<div
+				className="relative flex h-full min-h-64 items-center justify-center p-6"
+				style={{ backgroundColor: "#ccc9c0" }}
+			>
+				<div className="absolute top-4 left-4 flex gap-2 text-[10px] font-semibold">
+					<span className="rounded bg-green-500/25 px-2 py-0.5 text-green-900">
+						+2
+					</span>
+					<span className="rounded bg-yellow-400/35 px-2 py-0.5 text-yellow-950">
+						~3
+					</span>
+					<span className="rounded bg-red-500/25 px-2 py-0.5 text-red-900">
+						−1
+					</span>
+				</div>
+				<div className="flex gap-3">
+					<div className="rounded-sm bg-[#b8b5ae] px-3 py-2 text-xs ring-2 ring-yellow-500/70">
+						Move
+					</div>
+					<div className="rounded-sm bg-[#f5f07a] px-3 py-2 text-xs ring-2 ring-green-500/70">
+						Cull
+					</div>
+					<div className="rounded-sm bg-[#b8b5ae] px-3 py-2 text-xs opacity-50 ring-2 ring-red-500/70">
+						Panel
+					</div>
+				</div>
+				<p className="absolute right-4 bottom-4 left-4 rounded bg-black/70 px-3 py-2 text-[11px] text-neutral-200">
+					Input G: Mapping Flatten · Expression added
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className="relative flex h-full min-h-64 items-center justify-center p-6"
+			style={{ backgroundColor: "#ccc9c0" }}
+		>
+			<div className="relative rounded-sm bg-[#f5f07a] px-4 py-3 text-sm font-medium text-neutral-900">
+				Number
+				<span className="absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full bg-amber-400 font-mono text-[10px] text-neutral-900">
+					*
+				</span>
+			</div>
+			<div className="absolute top-1/2 left-1/2 mt-10 w-52 -translate-x-1/2 rounded-md border border-neutral-600 bg-neutral-950 p-3 shadow-xl">
+				<p className="text-[10px] text-neutral-500 uppercase">Pinned expression</p>
+				<p className="mt-1 font-mono text-xs text-amber-100">Sin(t) * Radius</p>
+			</div>
+		</div>
+	);
+}

--- a/src/lib/static-pages.ts
+++ b/src/lib/static-pages.ts
@@ -3,6 +3,12 @@ export const STATIC_PRERENDER_PATHS = [
 	"/privacy",
 	"/terms-of-service",
 	"/duckerweb",
+	"/lp",
+	"/lp1",
+	"/lp2",
+	"/lp3",
+	"/lp4",
+	"/lp5",
 ] as const;
 
 export type StaticPrerenderPath = (typeof STATIC_PRERENDER_PATHS)[number];

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,6 +15,12 @@ import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as StaticTermsOfServiceRouteImport } from './routes/_static/terms-of-service'
 import { Route as StaticPrivacyRouteImport } from './routes/_static/privacy'
+import { Route as StaticLp5RouteImport } from './routes/_static/lp5'
+import { Route as StaticLp4RouteImport } from './routes/_static/lp4'
+import { Route as StaticLp3RouteImport } from './routes/_static/lp3'
+import { Route as StaticLp2RouteImport } from './routes/_static/lp2'
+import { Route as StaticLp1RouteImport } from './routes/_static/lp1'
+import { Route as StaticLpRouteImport } from './routes/_static/lp'
 import { Route as StaticDuckerwebRouteImport } from './routes/_static/duckerweb'
 import { Route as AuthedGhcardsRouteImport } from './routes/_authed/ghcards'
 
@@ -46,6 +52,36 @@ const StaticPrivacyRoute = StaticPrivacyRouteImport.update({
   path: '/privacy',
   getParentRoute: () => StaticRoute,
 } as any)
+const StaticLp5Route = StaticLp5RouteImport.update({
+  id: '/lp5',
+  path: '/lp5',
+  getParentRoute: () => StaticRoute,
+} as any)
+const StaticLp4Route = StaticLp4RouteImport.update({
+  id: '/lp4',
+  path: '/lp4',
+  getParentRoute: () => StaticRoute,
+} as any)
+const StaticLp3Route = StaticLp3RouteImport.update({
+  id: '/lp3',
+  path: '/lp3',
+  getParentRoute: () => StaticRoute,
+} as any)
+const StaticLp2Route = StaticLp2RouteImport.update({
+  id: '/lp2',
+  path: '/lp2',
+  getParentRoute: () => StaticRoute,
+} as any)
+const StaticLp1Route = StaticLp1RouteImport.update({
+  id: '/lp1',
+  path: '/lp1',
+  getParentRoute: () => StaticRoute,
+} as any)
+const StaticLpRoute = StaticLpRouteImport.update({
+  id: '/lp',
+  path: '/lp',
+  getParentRoute: () => StaticRoute,
+} as any)
 const StaticDuckerwebRoute = StaticDuckerwebRouteImport.update({
   id: '/duckerweb',
   path: '/duckerweb',
@@ -62,6 +98,12 @@ export interface FileRoutesByFullPath {
   '/share': typeof ShareRoute
   '/ghcards': typeof AuthedGhcardsRoute
   '/duckerweb': typeof StaticDuckerwebRoute
+  '/lp': typeof StaticLpRoute
+  '/lp1': typeof StaticLp1Route
+  '/lp2': typeof StaticLp2Route
+  '/lp3': typeof StaticLp3Route
+  '/lp4': typeof StaticLp4Route
+  '/lp5': typeof StaticLp5Route
   '/privacy': typeof StaticPrivacyRoute
   '/terms-of-service': typeof StaticTermsOfServiceRoute
 }
@@ -70,6 +112,12 @@ export interface FileRoutesByTo {
   '/share': typeof ShareRoute
   '/ghcards': typeof AuthedGhcardsRoute
   '/duckerweb': typeof StaticDuckerwebRoute
+  '/lp': typeof StaticLpRoute
+  '/lp1': typeof StaticLp1Route
+  '/lp2': typeof StaticLp2Route
+  '/lp3': typeof StaticLp3Route
+  '/lp4': typeof StaticLp4Route
+  '/lp5': typeof StaticLp5Route
   '/privacy': typeof StaticPrivacyRoute
   '/terms-of-service': typeof StaticTermsOfServiceRoute
 }
@@ -81,6 +129,12 @@ export interface FileRoutesById {
   '/share': typeof ShareRoute
   '/_authed/ghcards': typeof AuthedGhcardsRoute
   '/_static/duckerweb': typeof StaticDuckerwebRoute
+  '/_static/lp': typeof StaticLpRoute
+  '/_static/lp1': typeof StaticLp1Route
+  '/_static/lp2': typeof StaticLp2Route
+  '/_static/lp3': typeof StaticLp3Route
+  '/_static/lp4': typeof StaticLp4Route
+  '/_static/lp5': typeof StaticLp5Route
   '/_static/privacy': typeof StaticPrivacyRoute
   '/_static/terms-of-service': typeof StaticTermsOfServiceRoute
 }
@@ -91,6 +145,12 @@ export interface FileRouteTypes {
     | '/share'
     | '/ghcards'
     | '/duckerweb'
+    | '/lp'
+    | '/lp1'
+    | '/lp2'
+    | '/lp3'
+    | '/lp4'
+    | '/lp5'
     | '/privacy'
     | '/terms-of-service'
   fileRoutesByTo: FileRoutesByTo
@@ -99,6 +159,12 @@ export interface FileRouteTypes {
     | '/share'
     | '/ghcards'
     | '/duckerweb'
+    | '/lp'
+    | '/lp1'
+    | '/lp2'
+    | '/lp3'
+    | '/lp4'
+    | '/lp5'
     | '/privacy'
     | '/terms-of-service'
   id:
@@ -109,6 +175,12 @@ export interface FileRouteTypes {
     | '/share'
     | '/_authed/ghcards'
     | '/_static/duckerweb'
+    | '/_static/lp'
+    | '/_static/lp1'
+    | '/_static/lp2'
+    | '/_static/lp3'
+    | '/_static/lp4'
+    | '/_static/lp5'
     | '/_static/privacy'
     | '/_static/terms-of-service'
   fileRoutesById: FileRoutesById
@@ -164,6 +236,48 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof StaticPrivacyRouteImport
       parentRoute: typeof StaticRoute
     }
+    '/_static/lp5': {
+      id: '/_static/lp5'
+      path: '/lp5'
+      fullPath: '/lp5'
+      preLoaderRoute: typeof StaticLp5RouteImport
+      parentRoute: typeof StaticRoute
+    }
+    '/_static/lp4': {
+      id: '/_static/lp4'
+      path: '/lp4'
+      fullPath: '/lp4'
+      preLoaderRoute: typeof StaticLp4RouteImport
+      parentRoute: typeof StaticRoute
+    }
+    '/_static/lp3': {
+      id: '/_static/lp3'
+      path: '/lp3'
+      fullPath: '/lp3'
+      preLoaderRoute: typeof StaticLp3RouteImport
+      parentRoute: typeof StaticRoute
+    }
+    '/_static/lp2': {
+      id: '/_static/lp2'
+      path: '/lp2'
+      fullPath: '/lp2'
+      preLoaderRoute: typeof StaticLp2RouteImport
+      parentRoute: typeof StaticRoute
+    }
+    '/_static/lp1': {
+      id: '/_static/lp1'
+      path: '/lp1'
+      fullPath: '/lp1'
+      preLoaderRoute: typeof StaticLp1RouteImport
+      parentRoute: typeof StaticRoute
+    }
+    '/_static/lp': {
+      id: '/_static/lp'
+      path: '/lp'
+      fullPath: '/lp'
+      preLoaderRoute: typeof StaticLpRouteImport
+      parentRoute: typeof StaticRoute
+    }
     '/_static/duckerweb': {
       id: '/_static/duckerweb'
       path: '/duckerweb'
@@ -194,12 +308,24 @@ const AuthedRouteWithChildren =
 
 interface StaticRouteChildren {
   StaticDuckerwebRoute: typeof StaticDuckerwebRoute
+  StaticLpRoute: typeof StaticLpRoute
+  StaticLp1Route: typeof StaticLp1Route
+  StaticLp2Route: typeof StaticLp2Route
+  StaticLp3Route: typeof StaticLp3Route
+  StaticLp4Route: typeof StaticLp4Route
+  StaticLp5Route: typeof StaticLp5Route
   StaticPrivacyRoute: typeof StaticPrivacyRoute
   StaticTermsOfServiceRoute: typeof StaticTermsOfServiceRoute
 }
 
 const StaticRouteChildren: StaticRouteChildren = {
   StaticDuckerwebRoute: StaticDuckerwebRoute,
+  StaticLpRoute: StaticLpRoute,
+  StaticLp1Route: StaticLp1Route,
+  StaticLp2Route: StaticLp2Route,
+  StaticLp3Route: StaticLp3Route,
+  StaticLp4Route: StaticLp4Route,
+  StaticLp5Route: StaticLp5Route,
   StaticPrivacyRoute: StaticPrivacyRoute,
   StaticTermsOfServiceRoute: StaticTermsOfServiceRoute,
 }

--- a/src/routes/_static/lp.tsx
+++ b/src/routes/_static/lp.tsx
@@ -1,0 +1,48 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { LandingShell, LANDING_VARIANTS } from "@/app/landing/shell";
+
+export const Route = createFileRoute("/_static/lp")({
+	head: () => ({
+		meta: [{ title: "Hopper Clip — Landing variants" }],
+	}),
+	component: LandingGallery,
+});
+
+function LandingGallery() {
+	return (
+		<LandingShell active="/lp">
+			<div className="mx-auto max-w-3xl py-10">
+				<p className="text-4xl font-bold tracking-tight md:text-5xl">
+					Hopper Clip
+				</p>
+				<h1 className="mt-4 text-2xl font-semibold">Landing variant gallery</h1>
+				<p className="mt-3 text-neutral-400">
+					Five interactive proposals reflecting Diff, native paste, .gh import,
+					and expression inspect. Pick one to promote to{" "}
+					<code className="rounded bg-neutral-800 px-1.5 py-0.5 text-sm">/</code>{" "}
+					later.
+				</p>
+				<ul className="mt-10 space-y-3">
+					{LANDING_VARIANTS.map((variant) => (
+						<li key={variant.path}>
+							<Link
+								to={variant.path}
+								className="flex items-center justify-between rounded-xl border border-neutral-800 bg-neutral-950 px-5 py-4 transition-colors hover:border-neutral-500 hover:bg-neutral-900"
+							>
+								<div>
+									<p className="font-medium">{variant.title}</p>
+									<p className="mt-1 font-mono text-xs text-neutral-500">
+										{variant.path}
+									</p>
+								</div>
+								<span className="rounded-md bg-neutral-800 px-2.5 py-1 font-mono text-sm">
+									{variant.label}
+								</span>
+							</Link>
+						</li>
+					))}
+				</ul>
+			</div>
+		</LandingShell>
+	);
+}

--- a/src/routes/_static/lp.tsx
+++ b/src/routes/_static/lp.tsx
@@ -17,9 +17,12 @@ function LandingGallery() {
 				</p>
 				<h1 className="mt-4 text-2xl font-semibold">Landing variant gallery</h1>
 				<p className="mt-3 text-neutral-400">
-					Five interactive proposals reflecting Diff, native paste, .gh import,
-					and expression inspect. Pick one to promote to{" "}
-					<code className="rounded bg-neutral-800 px-1.5 py-0.5 text-sm">/</code>{" "}
+					Five interactive proposals. Each explains Hopper Clip (online
+					pastebin) vs DuckerWeb (local-first .gh inspector), then demos Diff,
+					paste, and expression inspect. Pick one to promote to{" "}
+					<code className="rounded bg-neutral-800 px-1.5 py-0.5 text-sm">
+						/
+					</code>{" "}
 					later.
 				</p>
 				<ul className="mt-10 space-y-3">

--- a/src/routes/_static/lp1.tsx
+++ b/src/routes/_static/lp1.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { LandingShell } from "@/app/landing/shell";
+import { Lp1DiffTheater } from "@/app/landing/variants/lp1-diff-theater";
+
+export const Route = createFileRoute("/_static/lp1")({
+	head: () => ({
+		meta: [
+			{
+				title: "Hopper Clip — Diff Theater (landing review)",
+			},
+		],
+	}),
+	component: () => (
+		<LandingShell active="/lp1">
+			<Lp1DiffTheater />
+		</LandingShell>
+	),
+});

--- a/src/routes/_static/lp2.tsx
+++ b/src/routes/_static/lp2.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { LandingShell } from "@/app/landing/shell";
+import { Lp2PasteLab } from "@/app/landing/variants/lp2-paste-lab";
+
+export const Route = createFileRoute("/_static/lp2")({
+	head: () => ({
+		meta: [
+			{
+				title: "Hopper Clip — Paste Lab (landing review)",
+			},
+		],
+	}),
+	component: () => (
+		<LandingShell active="/lp2">
+			<Lp2PasteLab />
+		</LandingShell>
+	),
+});

--- a/src/routes/_static/lp3.tsx
+++ b/src/routes/_static/lp3.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { LandingShell } from "@/app/landing/shell";
+import { Lp3ExpressionLab } from "@/app/landing/variants/lp3-expression-lab";
+
+export const Route = createFileRoute("/_static/lp3")({
+	head: () => ({
+		meta: [
+			{
+				title: "Hopper Clip — Expression Lab (landing review)",
+			},
+		],
+	}),
+	component: () => (
+		<LandingShell active="/lp3">
+			<Lp3ExpressionLab />
+		</LandingShell>
+	),
+});

--- a/src/routes/_static/lp4.tsx
+++ b/src/routes/_static/lp4.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { LandingShell } from "@/app/landing/shell";
+import { Lp4SplitStory } from "@/app/landing/variants/lp4-split-story";
+
+export const Route = createFileRoute("/_static/lp4")({
+	head: () => ({
+		meta: [
+			{
+				title: "Hopper Clip — Split Story (landing review)",
+			},
+		],
+	}),
+	component: () => (
+		<LandingShell active="/lp4">
+			<Lp4SplitStory />
+		</LandingShell>
+	),
+});

--- a/src/routes/_static/lp5.tsx
+++ b/src/routes/_static/lp5.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { LandingShell } from "@/app/landing/shell";
+import { Lp5ProductTour } from "@/app/landing/variants/lp5-product-tour";
+
+export const Route = createFileRoute("/_static/lp5")({
+	head: () => ({
+		meta: [
+			{
+				title: "Hopper Clip — Product Tour (landing review)",
+			},
+		],
+	}),
+	component: () => (
+		<LandingShell active="/lp5">
+			<Lp5ProductTour />
+		</LandingShell>
+	),
+});

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -204,3 +204,12 @@
 		background-color: transparent !important;
 	}
 }
+
+@keyframes tourProgress {
+	from {
+		width: 0%;
+	}
+	to {
+		width: 100%;
+	}
+}


### PR DESCRIPTION
## Summary
- Adds five interactive landing proposals for review at `/lp1`–`/lp5`, plus a gallery at `/lp`.
- Every variant now leads with the product split: **Hopper Clip** = online pastebin (save/share GH scripts); **DuckerWeb** = local-first .gh inspector (graph, Diff, expressions — no upload unless you save a card).
- Still demos recent features: logic Diff, native paste / `.gh` drop, expression hover-to-pin.
- Leaves `/` unchanged so you can pick a winner later.

## Variants
1. **/lp1 Diff Theater** — Original / Changed / Diff toggle + change rail; contrast section below
2. **/lp2 Paste Lab** — ⌘/Ctrl+V or drop simulation → “save online” vs “inspect locally”
3. **/lp3 Expression Lab** — Hover/pin `*` badges on a local canvas; product contrast below
4. **/lp4 Split Story** — Online vs local slider/hover panels (core framing as the interaction)
5. **/lp5 Product Tour** — Autoplay walkthrough: what it is → import → save/share → DuckerWeb → Diff → inspect

## Test plan
- [ ] Open `/lp` and visit each `/lp1`–`/lp5`
- [ ] Confirm each page clearly states Clip (online) vs DuckerWeb (local-first)
- [ ] LP1: toggle stages; click nodes for change details
- [ ] LP2: press ⌘/Ctrl+V or Simulate paste; try drop zone
- [ ] LP3: hover/pin `*`; Esc / outside dismiss
- [ ] LP4: drag slider; hover either side
- [ ] LP5: autoplay + Pause; click step chips; Online/Local badges make sense
- [ ] Sign up / DuckerWeb CTAs work on desktop and mobile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a landing-page gallery with five interactive product experiences.
  * Explore diff visualization, paste-and-drop import, expression inspection, online/local comparison, and an automated product tour.
  * Added sign-up and DuckerWeb navigation call-to-actions.
  * Added navigation between landing-page variants with responsive layouts and animated tour progress.
  * Landing experiences are available at `/lp` and `/lp1`–`/lp5`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->