### PR TITLE
Add development flow component gallery

### DIFF
--- a/parser/src/parser.test.ts
+++ b/parser/src/parser.test.ts
@@ -103,3 +103,48 @@ describe("buildGhJson parameter options", () => {
 		});
 	});
 });
+
+describe("buildGhJson wire display", () => {
+	it("parses normal, faint, and hidden styles from direct param_input chunks", () => {
+		const target = (index: number, style?: number) => `
+			<chunk name="Object" index="${index}">
+				<items><item name="GUID">target-type-${index}</item><item name="Name">Target</item></items>
+				<chunks><chunk name="Container">
+					<items><item name="InstanceGuid">target-${index}</item><item name="NickName">Target ${index}</item></items>
+					<chunks><chunk name="param_input" index="0"><items>
+						<item name="NickName">I</item>
+						<item name="InstanceGuid">input-${index}</item>
+						<item name="Source" index="0">source-output</item>
+						<item name="SourceCount">1</item>
+						${style === undefined ? "" : `<item name="WireDisplay" type_name="gh_int32">${style}</item>`}
+					</items></chunk></chunks>
+				</chunk></chunks>
+			</chunk>`;
+
+		const xml = `
+			<Archive name="Root">
+				<chunks><chunk name="Clipboard"><chunks><chunk name="DefinitionObjects"><chunks>
+					<chunk name="Object" index="0">
+						<items><item name="GUID">source-type</item><item name="Name">Source</item></items>
+						<chunks><chunk name="Container">
+							<items><item name="InstanceGuid">source</item><item name="NickName">Source</item></items>
+							<chunks><chunk name="param_output" index="0"><items>
+								<item name="NickName">O</item><item name="InstanceGuid">source-output</item>
+							</items></chunk></chunks>
+						</chunk></chunks>
+					</chunk>
+					${target(1)}
+					${target(2, 1)}
+					${target(3, 2)}
+				</chunks></chunk></chunks></chunk></chunks>
+			</Archive>`;
+
+		const parsed = buildGhJson(xml, { includeVisuals: true });
+
+		expect(parsed.wires.map((wire) => wire.style)).toEqual([
+			"normal",
+			"faint",
+			"hidden",
+		]);
+	});
+});

--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -200,7 +200,8 @@ function parsePortOptions(
 
 function parseParamChunk(
 	paramChunk: XmlChunk,
-	type: "input" | "output"
+	type: "input" | "output",
+	includeVisuals = false
 ): InputPort | OutputPort | null {
 	const items = extractItems(paramChunk);
 
@@ -217,6 +218,12 @@ function parseParamChunk(
 	};
 
 	if (type === "input") {
+		if (includeVisuals) {
+			const wireDisplay = items.WireDisplay;
+			(port as InputPort).wireStyle =
+				wireDisplay === 1 ? "faint" : wireDisplay === 2 ? "hidden" : "normal";
+		}
+
 		const sources = extractIndexedItems(paramChunk, "Source");
 		if (sources.length > 0) {
 			(port as InputPort).source = sources[0];
@@ -540,7 +547,11 @@ function parseComponent(
 		const inputParams = findAllChunks(paramDataChunk, "InputParam");
 
 		for (let i = 0; i < inputCount && i < inputParams.length; i++) {
-			const param = parseParamChunk(inputParams[i], "input");
+			const param = parseParamChunk(
+				inputParams[i],
+				"input",
+				options?.includeVisuals
+			);
 			if (param && param.nick) {
 				const key = String(param.nick).toLowerCase();
 				component.inputs[key] = param;
@@ -565,7 +576,7 @@ function parseComponent(
 	const seenInputKeys = new Set<string>();
 	const paramInputs = findAllChunks(containerChunk, "param_input");
 	for (const paramChunk of paramInputs) {
-		const param = parseParamChunk(paramChunk, "input");
+		const param = parseParamChunk(paramChunk, "input", options?.includeVisuals);
 		if (param && param.nick) {
 			let key = String(param.nick).toLowerCase();
 			if (seenInputKeys.has(key)) {
@@ -797,6 +808,9 @@ export function parseGrasshopper(
 					wires.push({
 						from: resolvedFrom,
 						to: `${compId}.${inputName}`,
+						...(options?.includeVisuals && {
+							style: input.wireStyle ?? "normal",
+						}),
 						sourceComponentGuid: src,
 						targetPortGuid: input.instanceGuid,
 					});
@@ -804,6 +818,9 @@ export function parseGrasshopper(
 					wires.push({
 						from: src,
 						to: `${compId}.${inputName}`,
+						...(options?.includeVisuals && {
+							style: input.wireStyle ?? "normal",
+						}),
 						sourceComponentGuid: src,
 						targetPortGuid: input.instanceGuid,
 					});

--- a/parser/src/types.ts
+++ b/parser/src/types.ts
@@ -27,6 +27,7 @@ export interface InputPort {
 	sources?: string[];
 	optional?: boolean;
 	options?: PortOptions;
+	wireStyle?: WireStyle;
 	instanceGuid: string;
 }
 

--- a/src/app/dev/flow-gallery-fixtures.ts
+++ b/src/app/dev/flow-gallery-fixtures.ts
@@ -171,19 +171,30 @@ export const flowGalleryNodes: GHNode[] = [
 
 export const flowGalleryEdges: Edge[] = [
 	{
-		id: "slider-to-component",
-		source: "slider",
-		sourceHandle: "out",
+		id: "normal-wire",
+		source: "component-normal",
+		sourceHandle: "result",
 		target: "component-hidden",
 		targetHandle: "geometry",
 		type: "default",
+		data: { wireStyle: "normal" },
 	},
 	{
-		id: "component-to-panel",
-		source: "component-normal",
-		sourceHandle: "result",
-		target: "panel",
+		id: "faint-wire",
+		source: "component-hidden",
+		sourceHandle: "out",
+		target: "component-locked",
 		targetHandle: "in",
 		type: "default",
+		data: { wireStyle: "faint" },
+	},
+	{
+		id: "hidden-wire",
+		source: "component-locked",
+		sourceHandle: "out",
+		target: "script",
+		targetHandle: "x",
+		type: "default",
+		data: { wireStyle: "hidden" },
 	},
 ];

--- a/src/app/dev/flow-gallery-fixtures.ts
+++ b/src/app/dev/flow-gallery-fixtures.ts
@@ -1,0 +1,189 @@
+import type { Edge } from "@xyflow/react";
+import type { GHNode } from "@/app/duckerweb/types/type";
+
+const input = (id: string, label: string) => ({ id, label });
+const output = (id: string, label: string) => ({ id, label });
+
+export const flowGalleryNodes: GHNode[] = [
+	{
+		id: "component-normal",
+		type: "component",
+		position: { x: 80, y: 80 },
+		data: {
+			label: "Addition",
+			type: "component",
+			inputs: [input("a", "A"), input("b", "B")],
+			outputs: [output("result", "Result")],
+		},
+	},
+	{
+		id: "component-hidden",
+		type: "component",
+		position: { x: 330, y: 80 },
+		data: {
+			label: "Long component name",
+			type: "component",
+			runtimeState: "hidden",
+			inputs: [
+				input("geometry", "Geometry"),
+				input("very-long", "Very long input label"),
+			],
+			outputs: [output("out", "Output")],
+		},
+	},
+	{
+		id: "component-locked",
+		type: "component",
+		position: { x: 660, y: 80 },
+		selected: true,
+		data: {
+			label: "Locked",
+			type: "component",
+			runtimeState: "locked",
+			inputs: [input("in", "Input")],
+			outputs: [output("out", "Output")],
+		},
+	},
+	{
+		id: "script",
+		type: "script",
+		position: { x: 920, y: 65 },
+		data: {
+			label: "Python 3",
+			type: "script",
+			inputs: [input("x", "x"), input("y", "y")],
+			outputs: [output("a", "a")],
+			script: {
+				language: "python",
+				title: "Gallery example",
+				code: "a = x + y\nprint(a)",
+			},
+		},
+	},
+	{
+		id: "panel",
+		type: "panel",
+		position: { x: 80, y: 300 },
+		data: {
+			label: "Panel",
+			type: "panel",
+			value: "Preview text\n123.456",
+			height: 52,
+			inputs: [input("in", "")],
+			outputs: [output("out", "")],
+		},
+	},
+	{
+		id: "slider",
+		type: "slider",
+		position: { x: 330, y: 310 },
+		data: {
+			label: "Number Slider",
+			type: "slider",
+			value: "4.20",
+			percent: 42,
+			inputs: [],
+			outputs: [output("out", "Value")],
+		},
+	},
+	{
+		id: "value-list",
+		type: "valueList",
+		position: { x: 650, y: 310 },
+		data: {
+			label: "Quality",
+			type: "valueList",
+			value: "High",
+			inputs: [],
+			outputs: [output("out", "Selected")],
+		},
+	},
+	{
+		id: "toggle",
+		type: "toggle",
+		position: { x: 920, y: 310 },
+		data: {
+			label: "Enabled",
+			type: "toggle",
+			value: "True",
+			inputs: [],
+			outputs: [output("out", "Boolean")],
+		},
+	},
+	{
+		id: "group",
+		type: "group",
+		position: { x: 45, y: 260 },
+		style: { width: 1100, height: 315 },
+		zIndex: 0,
+		data: {
+			label: "Inputs, values, and utility components",
+			type: "group",
+			inputs: [],
+			outputs: [],
+			members: [
+				"panel",
+				"slider",
+				"value-list",
+				"toggle",
+				"swatch",
+				"button",
+				"relay",
+			],
+			containerBounds: { x: 45, y: 260, width: 1100, height: 315 },
+		},
+	},
+	{
+		id: "swatch",
+		type: "swatch",
+		position: { x: 80, y: 500 },
+		data: {
+			label: "Colour Swatch",
+			type: "swatch",
+			color: "255;67;154;224",
+			inputs: [],
+			outputs: [output("out", "Colour")],
+		},
+	},
+	{
+		id: "button",
+		type: "button",
+		position: { x: 330, y: 500 },
+		data: {
+			label: "Run solver",
+			type: "button",
+			inputs: [],
+			outputs: [output("out", "Pressed")],
+		},
+	},
+	{
+		id: "relay",
+		type: "relay",
+		position: { x: 650, y: 500 },
+		data: {
+			label: "Geometry relay",
+			type: "relay",
+			inputs: [input("in", "Input")],
+			outputs: [output("out", "Geometry")],
+		},
+	},
+];
+
+export const flowGalleryEdges: Edge[] = [
+	{
+		id: "slider-to-component",
+		source: "slider",
+		sourceHandle: "out",
+		target: "component-hidden",
+		targetHandle: "geometry",
+		type: "default",
+	},
+	{
+		id: "component-to-panel",
+		source: "component-normal",
+		sourceHandle: "result",
+		target: "panel",
+		targetHandle: "in",
+		type: "default",
+	},
+];

--- a/src/app/dev/flow-gallery.tsx
+++ b/src/app/dev/flow-gallery.tsx
@@ -1,0 +1,13 @@
+import { GHFlowCanvas } from "@/app/duckerweb/components/GHFlowCanvas";
+import {
+	flowGalleryEdges,
+	flowGalleryNodes,
+} from "@/app/dev/flow-gallery-fixtures";
+
+export default function FlowGallery() {
+	return (
+		<main className="h-screen min-h-[600px] w-screen">
+			<GHFlowCanvas nodes={flowGalleryNodes} edges={flowGalleryEdges} />
+		</main>
+	);
+}

--- a/src/app/dev/flow-gallery.tsx
+++ b/src/app/dev/flow-gallery.tsx
@@ -6,8 +6,23 @@ import {
 
 export default function FlowGallery() {
 	return (
-		<main className="h-screen min-h-[600px] w-screen">
+		<main className="relative h-screen min-h-[600px] w-screen">
 			<GHFlowCanvas nodes={flowGalleryNodes} edges={flowGalleryEdges} />
+			<aside className="pointer-events-none absolute bottom-4 left-4 z-10 rounded-md border border-[#999790] bg-[#ebe9e4]/95 px-3 py-2.5 text-xs text-[#3f3f3c] shadow-md">
+				<p className="mb-2 font-semibold">Wire display gallery</p>
+				<div className="grid grid-cols-[52px_70px] items-center gap-x-2 gap-y-1.5">
+					<span>Normal</span>
+					<span className="h-px bg-[#555552]" />
+					<span>Faint</span>
+					<span className="h-px bg-[#555552]/30" />
+					<span>Hidden</span>
+					<span className="border-t border-dashed border-[#555552]/35" />
+				</div>
+				<p className="mt-2 max-w-52 text-[11px] text-[#65645f]">
+					Click Locked or Python 3 to reveal their hidden wire, or use the
+					Hidden wires toggle.
+				</p>
+			</aside>
 		</main>
 	);
 }

--- a/src/app/duckerweb/components/GHEdge.tsx
+++ b/src/app/duckerweb/components/GHEdge.tsx
@@ -10,6 +10,7 @@ export function GHEdge({
 	targetPosition,
 	selected,
 	style,
+	data,
 }: GHEdgeProps) {
 	const [edgePath] = getBezierPath({
 		sourceX,
@@ -20,6 +21,9 @@ export function GHEdge({
 		targetPosition,
 		curvature: 0.35,
 	});
+	const wireStyle = data?.wireStyle ?? "normal";
+	const isHidden = wireStyle === "hidden";
+	const isVisible = !isHidden || data?.isRevealed;
 
 	return (
 		<BaseEdge
@@ -27,6 +31,16 @@ export function GHEdge({
 			style={{
 				stroke: "#555552",
 				strokeWidth: 1.5,
+				opacity: isVisible
+					? wireStyle === "faint"
+						? 0.28
+						: isHidden
+							? 0.32
+							: 1
+					: 0,
+				strokeDasharray: isHidden ? "4 4" : undefined,
+				pointerEvents: isVisible ? "auto" : "none",
+				transition: "opacity 160ms ease",
 				...style,
 				...(selected && { stroke: "#00a0ff", strokeWidth: 2, opacity: 1 }),
 			}}

--- a/src/app/duckerweb/components/GHFlowCanvas.tsx
+++ b/src/app/duckerweb/components/GHFlowCanvas.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
 	ReactFlow,
 	Background,
 	BackgroundVariant,
 	Controls,
+	Panel,
 	useReactFlow,
 	type NodeTypes,
 	type EdgeTypes,
 } from "@xyflow/react";
+import { Eye, EyeOff } from "lucide-react";
 import "@xyflow/react/dist/style.css";
 
 import { GHPanelNode } from "./GHPanelNode";
@@ -60,18 +62,39 @@ function FocusOnNode({ focus }: { focus: GHFlowCanvasProps["focus"] }) {
 }
 
 export function GHFlowCanvas({ nodes, edges, focus }: GHFlowCanvasProps) {
+	const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+	const [revealHiddenWires, setRevealHiddenWires] = useState(false);
 	const defaultEdgeOptions = useMemo(
 		() => ({
 			type: "default",
 		}),
 		[]
 	);
+	const visibleEdges = useMemo(
+		() =>
+			edges.map((edge) => {
+				const wireStyle = edge.data?.wireStyle;
+				if (wireStyle !== "hidden") return edge;
+
+				return {
+					...edge,
+					data: {
+						...edge.data,
+						isRevealed:
+							revealHiddenWires ||
+							edge.source === selectedNodeId ||
+							edge.target === selectedNodeId,
+					},
+				};
+			}),
+		[edges, revealHiddenWires, selectedNodeId]
+	);
 
 	return (
 		<div className="gh-canvas-container">
 			<ReactFlow
 				nodes={nodes}
-				edges={edges}
+				edges={visibleEdges}
 				nodeTypes={nodeTypes}
 				edgeTypes={edgeTypes}
 				defaultEdgeOptions={defaultEdgeOptions}
@@ -81,6 +104,8 @@ export function GHFlowCanvas({ nodes, edges, focus }: GHFlowCanvasProps) {
 				maxZoom={4}
 				proOptions={{ hideAttribution: true }}
 				colorMode="dark"
+				onNodeClick={(_, node) => setSelectedNodeId(node.id)}
+				onPaneClick={() => setSelectedNodeId(null)}
 			>
 				<Background
 					variant={BackgroundVariant.Lines}
@@ -90,6 +115,20 @@ export function GHFlowCanvas({ nodes, edges, focus }: GHFlowCanvasProps) {
 					color="#bbb8af"
 				/>
 				<Controls />
+				<Panel position="top-right">
+					<button
+						type="button"
+						aria-pressed={revealHiddenWires}
+						title={
+							revealHiddenWires ? "Hide hidden wires" : "Reveal hidden wires"
+						}
+						onClick={() => setRevealHiddenWires((current) => !current)}
+						className="flex items-center gap-1.5 rounded border border-[#8d8b86] bg-[#e5e3de]/95 px-2.5 py-1.5 text-xs font-medium text-[#3f3f3c] shadow-sm transition-colors hover:bg-white"
+					>
+						{revealHiddenWires ? <EyeOff size={14} /> : <Eye size={14} />}
+						Hidden wires
+					</button>
+				</Panel>
 				<FocusOnNode focus={focus} />
 			</ReactFlow>
 		</div>

--- a/src/app/duckerweb/components/GHPanelNode.tsx
+++ b/src/app/duckerweb/components/GHPanelNode.tsx
@@ -2,14 +2,14 @@ import type { GHNodeProps } from "../types/type";
 import { GHHandle } from "./Handle";
 import { HandlePosition } from "./HandlePosition";
 
-export function GHPanelNode({ data, selected }: GHNodeProps) {
+export function GHPanelNode({ data }: GHNodeProps) {
 	const inputs = data.inputs ?? [];
 	const outputs = data.outputs ?? [];
 
 	return (
 		<div className="relative overflow-visible">
 			<div
-				className={`relative flex items-center overflow-hidden rounded-sm border font-sans text-[10px] shadow-sm select-none ${selected ? "border-[#444]" : "border-[#b0aa40]"}`}
+				className="relative flex items-center overflow-hidden rounded-sm border border-[#444] font-sans text-[10px] shadow-sm select-none"
 				style={{
 					minWidth: 60,
 					height: data.height ?? 28,

--- a/src/app/duckerweb/components/GHSwatchNode.tsx
+++ b/src/app/duckerweb/components/GHSwatchNode.tsx
@@ -17,15 +17,16 @@ function semicolonRgbaToCss(input: string): string {
 export function GHSwatchNode({ data }: GHSwatchNodeProps) {
 	const bg = data.color ? semicolonRgbaToCss(data.color) : "#ddd";
 	return (
-		<div
-			className={`flex h-7 items-center overflow-hidden rounded-sm border border-none font-sans text-[10px] shadow-sm select-none`}
-			style={{
-				minWidth: 100,
-				backgroundColor: bg,
-			}}
-		>
-			<div className="flex h-full shrink-0 items-center border-r border-[#aaa] bg-[#b0ada6] px-2 font-medium text-[#222]">
-				{data.label ?? "Swatch"}
+		<div className="relative overflow-visible">
+			<div className="flex h-7 w-max items-center overflow-hidden rounded-sm border border-[#444] font-sans text-[10px] shadow-md select-none">
+				<div className="flex h-full min-w-11 items-center border-r border-[#444] bg-[#b0ada6] px-2 font-medium whitespace-nowrap text-[#222]">
+					{data.label ?? "Swatch"}
+				</div>
+				<div
+					aria-hidden
+					className="h-full w-14 shrink-0"
+					style={{ backgroundColor: bg }}
+				/>
 			</div>
 
 			<GHHandle

--- a/src/app/duckerweb/components/Handle.tsx
+++ b/src/app/duckerweb/components/Handle.tsx
@@ -1,5 +1,5 @@
 import { Handle, Position } from "@xyflow/react";
-import { HANDLE_SIZE } from "./constants";
+import { HANDLE_SIZE, HANDLE_STROKE } from "./constants";
 import type { GHHandleProps } from "../types/type";
 
 export function GHHandle({
@@ -15,8 +15,9 @@ export function GHHandle({
 				type={type}
 				position={position === "left" ? Position.Left : Position.Right}
 				id={id}
-				className={`!h-[9px] !w-[9px] !rounded-full !border !border-[#777] !bg-[#aaa] ${className}`}
+				className={`!h-[9px] !w-[9px] !rounded-full !border !bg-[#aaa] ${className}`}
 				style={{
+					borderColor: HANDLE_STROKE,
 					clipPath: "inset(0 0 0 50%)",
 				}}
 			/>
@@ -38,7 +39,7 @@ export function GHHandle({
 				height: HANDLE_SIZE,
 				flexShrink: 0,
 				borderRadius,
-				border: "2.2px solid #333",
+				border: `2.2px solid ${HANDLE_STROKE}`,
 				background: "#fff",
 				clipPath:
 					Position.Left === position ? "inset(0 50% 0 0)" : "inset(0 0 0 50%)",

--- a/src/app/duckerweb/components/constants.ts
+++ b/src/app/duckerweb/components/constants.ts
@@ -1,2 +1,3 @@
 export const HANDLE_SIZE = 10;
+export const HANDLE_STROKE = "#444";
 export const POSITION_SCALE_X = 1.25;

--- a/src/app/duckerweb/gh-flow-generator.test.ts
+++ b/src/app/duckerweb/gh-flow-generator.test.ts
@@ -16,6 +16,31 @@ test("generateFlowData maps wires onto connected source/target nodes", () => {
 	}
 });
 
+test("generateFlowData preserves wire display styles", () => {
+	const xml = fs.readFileSync("parser/sand/xmls/brep-area-Wire.xml", "utf8");
+	const parsed = buildGhJson(xml, { includeVisuals: true });
+	const wire = parsed.wires[0];
+	parsed.wires = [
+		{ ...wire, style: "faint" },
+		{ ...wire, style: "hidden" },
+	];
+
+	const { edges } = generateFlowData(parsed);
+
+	expect(edges[0].data?.wireStyle).toBe("faint");
+	expect(edges[1].data?.wireStyle).toBe("hidden");
+});
+
+test("generateFlowData reads faint wire styles from Grasshopper XML", () => {
+	const xml = fs.readFileSync(
+		"parser/sand/xmls/user_2wqbnxvyl1Wpms6P31fLGrwH2c3_w01KJ2ROEV8GrxvrtHv1A.xml",
+		"utf8"
+	);
+	const parsed = buildGhJson(xml, { includeVisuals: true });
+
+	expect(parsed.wires.some((wire) => wire.style === "faint")).toBe(true);
+});
+
 test("generateFlowData exposes standalone parameter internal expressions", () => {
 	const xml = fs.readFileSync(
 		"parser/sand/xmls/flatten-internal-expression.xml",

--- a/src/app/duckerweb/lib/edge-generator.ts
+++ b/src/app/duckerweb/lib/edge-generator.ts
@@ -26,6 +26,7 @@ export function generateEdges(
 				sourceHandle: wire.from,
 				target: targetId,
 				targetHandle: wire.to,
+				data: { wireStyle: wire.style ?? "normal" },
 			} as Edge;
 		})
 		.filter((edge): edge is Edge => edge !== null);

--- a/src/app/duckerweb/types/type.ts
+++ b/src/app/duckerweb/types/type.ts
@@ -266,6 +266,10 @@ export type GHEdgeProps = {
 	targetPosition: Position;
 	selected?: boolean;
 	style?: CSSProperties;
+	data?: {
+		wireStyle?: "normal" | "faint" | "hidden";
+		isRevealed?: boolean;
+	};
 };
 
 export type HandleVariant = "detailed" | "compact";

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as ShareRouteImport } from './routes/share'
 import { Route as StaticRouteImport } from './routes/_static'
 import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as DevFlowGalleryRouteImport } from './routes/dev/flow-gallery'
 import { Route as StaticTermsOfServiceRouteImport } from './routes/_static/terms-of-service'
 import { Route as StaticPrivacyRouteImport } from './routes/_static/privacy'
 import { Route as StaticDuckerwebRouteImport } from './routes/_static/duckerweb'
@@ -34,6 +35,11 @@ const AuthedRoute = AuthedRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DevFlowGalleryRoute = DevFlowGalleryRouteImport.update({
+  id: '/dev/flow-gallery',
+  path: '/dev/flow-gallery',
   getParentRoute: () => rootRouteImport,
 } as any)
 const StaticTermsOfServiceRoute = StaticTermsOfServiceRouteImport.update({
@@ -64,6 +70,7 @@ export interface FileRoutesByFullPath {
   '/duckerweb': typeof StaticDuckerwebRoute
   '/privacy': typeof StaticPrivacyRoute
   '/terms-of-service': typeof StaticTermsOfServiceRoute
+  '/dev/flow-gallery': typeof DevFlowGalleryRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -72,6 +79,7 @@ export interface FileRoutesByTo {
   '/duckerweb': typeof StaticDuckerwebRoute
   '/privacy': typeof StaticPrivacyRoute
   '/terms-of-service': typeof StaticTermsOfServiceRoute
+  '/dev/flow-gallery': typeof DevFlowGalleryRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -83,6 +91,7 @@ export interface FileRoutesById {
   '/_static/duckerweb': typeof StaticDuckerwebRoute
   '/_static/privacy': typeof StaticPrivacyRoute
   '/_static/terms-of-service': typeof StaticTermsOfServiceRoute
+  '/dev/flow-gallery': typeof DevFlowGalleryRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -93,6 +102,7 @@ export interface FileRouteTypes {
     | '/duckerweb'
     | '/privacy'
     | '/terms-of-service'
+    | '/dev/flow-gallery'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -101,6 +111,7 @@ export interface FileRouteTypes {
     | '/duckerweb'
     | '/privacy'
     | '/terms-of-service'
+    | '/dev/flow-gallery'
   id:
     | '__root__'
     | '/'
@@ -111,6 +122,7 @@ export interface FileRouteTypes {
     | '/_static/duckerweb'
     | '/_static/privacy'
     | '/_static/terms-of-service'
+    | '/dev/flow-gallery'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -118,6 +130,7 @@ export interface RootRouteChildren {
   AuthedRoute: typeof AuthedRouteWithChildren
   StaticRoute: typeof StaticRouteWithChildren
   ShareRoute: typeof ShareRoute
+  DevFlowGalleryRoute: typeof DevFlowGalleryRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -148,6 +161,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dev/flow-gallery': {
+      id: '/dev/flow-gallery'
+      path: '/dev/flow-gallery'
+      fullPath: '/dev/flow-gallery'
+      preLoaderRoute: typeof DevFlowGalleryRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_static/terms-of-service': {
@@ -212,6 +232,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthedRoute: AuthedRouteWithChildren,
   StaticRoute: StaticRouteWithChildren,
   ShareRoute: ShareRoute,
+  DevFlowGalleryRoute: DevFlowGalleryRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/dev/flow-gallery.tsx
+++ b/src/routes/dev/flow-gallery.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import FlowGallery from "@/app/dev/flow-gallery";
+
+export const Route = createFileRoute("/dev/flow-gallery")({
+	beforeLoad: () => {
+		if (!import.meta.env.DEV) {
+			throw notFound();
+		}
+	},
+	head: () => ({
+		meta: [{ title: "Flow Gallery | Hopper Clip" }],
+	}),
+	component: FlowGallery,
+});


### PR DESCRIPTION
## Summary
- add a dev-only `/dev/flow-gallery` route using the production React Flow canvas
- preview every flow node type with representative states, connections, and a populated group
- make the gallery full-canvas and align panel outlines with other components

## Validation
- `pnpm run check`
- `pnpm run build`
- CodeRabbit CLI review: 0 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a development-only Flow Gallery at `/dev/flow-gallery` with an interactive full-screen canvas and wiring display instructions.
  - Added support for visual wire styles (“normal”, “faint”, “hidden”), including a “Hidden wires” toggle that reveals relevant hidden connections.
- **Bug Fixes**
  - Updated panel styling to use consistent borders independent of selection state.
- **Tests**
  - Added coverage to verify wire display styles are parsed and preserved through generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->