### PR TITLE
Fix Grasshopper flow rendering fidelity

### DIFF
--- a/parser/src/parser.test.ts
+++ b/parser/src/parser.test.ts
@@ -214,3 +214,46 @@ describe("buildGhJson panel content", () => {
 		expect(panel.value).toEqual({ type: "panel", text: "2" });
 	});
 });
+
+describe("buildGhJson scribble content", () => {
+	it("preserves text geometry and font styling", () => {
+		const xml = `
+			<Archive name="Root">
+				<chunks><chunk name="Clipboard"><chunks><chunk name="DefinitionObjects"><chunks>
+					<chunk name="Object" index="0">
+						<items><item name="GUID">scribble-type</item><item name="Name">Scribble</item></items>
+						<chunks><chunk name="Container"><items>
+							<item name="InstanceGuid">scribble-instance</item>
+							<item name="NickName">Scribble</item>
+							<item name="Bold">false</item>
+							<item name="Italic">true</item>
+							<item name="Font">Arial</item>
+							<item name="Size">18</item>
+							<item name="Text">Sinuous interlocking seam</item>
+							<item name="Ca" type_name="gh_drawing_pointf"><X>660</X><Y>20</Y></item>
+							<item name="Cb" type_name="gh_drawing_pointf"><X>1118.2617</X><Y>20</Y></item>
+							<item name="Cc" type_name="gh_drawing_pointf"><X>1118.2617</X><Y>36.89258</Y></item>
+							<item name="Cd" type_name="gh_drawing_pointf"><X>660</X><Y>36.89258</Y></item>
+						</items></chunk></chunks>
+					</chunk>
+				</chunks></chunk></chunks></chunk></chunks>
+			</Archive>`;
+
+		const scribble = buildGhJson(xml).components.Scribble;
+
+		expect(scribble.value).toEqual({
+			type: "scribble",
+			text: "Sinuous interlocking seam",
+			font: "Arial",
+			size: 18,
+			bold: false,
+			italic: true,
+			corners: {
+				a: { x: 660, y: 20 },
+				b: { x: 1118.2617, y: 20 },
+				c: { x: 1118.2617, y: 36.89258 },
+				d: { x: 660, y: 36.89258 },
+			},
+		});
+	});
+});

--- a/parser/src/parser.test.ts
+++ b/parser/src/parser.test.ts
@@ -148,3 +148,69 @@ describe("buildGhJson wire display", () => {
 		]);
 	});
 });
+
+describe("buildGhJson parameter visuals", () => {
+	it("parses input and output bounds and pivots", () => {
+		const xml = `
+			<Archive name="Root">
+				<chunks><chunk name="Clipboard"><chunks><chunk name="DefinitionObjects"><chunks>
+					<chunk name="Object" index="0">
+						<items><item name="GUID">sphere-type</item><item name="Name">Mesh Sphere</item></items>
+						<chunks><chunk name="Container">
+							<items><item name="InstanceGuid">sphere</item><item name="NickName">MSphere</item></items>
+							<chunks>
+								<chunk name="param_input" index="0">
+									<items><item name="NickName">B</item><item name="InstanceGuid">base</item></items>
+									<chunks><chunk name="Attributes"><items>
+										<item name="Bounds" type_name="gh_drawing_rectanglef"><X>157</X><Y>504</Y><W>10</W><H>20</H></item>
+										<item name="Pivot" type_name="gh_drawing_pointf"><X>163.5</X><Y>514</Y></item>
+									</items></chunk></chunks>
+								</chunk>
+								<chunk name="param_output" index="0">
+									<items><item name="NickName">M</item><item name="InstanceGuid">mesh</item></items>
+									<chunks><chunk name="Attributes"><items>
+										<item name="Bounds" type_name="gh_drawing_rectanglef"><X>197</X><Y>504</Y><W>14</W><H>80</H></item>
+										<item name="Pivot" type_name="gh_drawing_pointf"><X>204</X><Y>544</Y></item>
+									</items></chunk></chunks>
+								</chunk>
+							</chunks>
+						</chunk></chunks>
+					</chunk>
+				</chunks></chunk></chunks></chunk></chunks>
+			</Archive>`;
+
+		const parsed = buildGhJson(xml, { includeVisuals: true });
+
+		expect(parsed.components.MSphere.inputs.b.visuals).toEqual({
+			bounds: { x: 157, y: 504, width: 10, height: 20 },
+			pivot: { x: 163.5, y: 514 },
+		});
+		expect(parsed.components.MSphere.outputs.m.visuals).toEqual({
+			bounds: { x: 197, y: 504, width: 14, height: 80 },
+			pivot: { x: 204, y: 544 },
+		});
+	});
+});
+
+describe("buildGhJson panel content", () => {
+	it("preserves a custom panel heading separately from its body text", () => {
+		const xml = `
+			<Archive name="Root">
+				<chunks><chunk name="Clipboard"><chunks><chunk name="DefinitionObjects"><chunks>
+					<chunk name="Object" index="0">
+						<items><item name="GUID">panel-type</item><item name="Name">Panel</item></items>
+						<chunks><chunk name="Container"><items>
+							<item name="InstanceGuid">panel-instance</item>
+							<item name="NickName">constant 2</item>
+							<item name="UserText">2</item>
+						</items></chunk></chunks>
+					</chunk>
+				</chunks></chunk></chunks></chunk></chunks>
+			</Archive>`;
+
+		const panel = buildGhJson(xml).components["constant 2"];
+
+		expect(panel.nickName).toBe("constant 2");
+		expect(panel.value).toEqual({ type: "panel", text: "2" });
+	});
+});

--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -216,6 +216,10 @@ function parseParamChunk(
 		optional: (items.Optional as boolean) ?? false,
 		instanceGuid,
 	};
+	if (includeVisuals) {
+		const visuals = parseVisuals(paramChunk, items);
+		if (visuals) port.visuals = visuals;
+	}
 
 	if (type === "input") {
 		if (includeVisuals) {
@@ -331,11 +335,11 @@ function parseComponentValue(
 
 	// Parse Panel text
 	if (type.includes("panel")) {
-		const text = containerItems.UserText as string;
-		if (text !== undefined) {
+		const userText = containerItems.UserText;
+		if (userText !== undefined) {
 			return {
 				type: "panel",
-				text,
+				text: String(userText),
 			};
 		}
 	}
@@ -563,7 +567,11 @@ function parseComponent(
 		const outputParams = findAllChunks(paramDataChunk, "OutputParam");
 
 		for (let i = 0; i < outputCount && i < outputParams.length; i++) {
-			const param = parseParamChunk(outputParams[i], "output");
+			const param = parseParamChunk(
+				outputParams[i],
+				"output",
+				options?.includeVisuals
+			);
 			if (param && param.nick) {
 				const key = String(param.nick).toLowerCase();
 				component.outputs[key] = param;
@@ -590,7 +598,11 @@ function parseComponent(
 	const seenOutputKeys = new Set<string>();
 	const paramOutputs = findAllChunks(containerChunk, "param_output");
 	for (const paramChunk of paramOutputs) {
-		const param = parseParamChunk(paramChunk, "output");
+		const param = parseParamChunk(
+			paramChunk,
+			"output",
+			options?.includeVisuals
+		);
 		if (param && param.nick) {
 			let key = String(param.nick).toLowerCase();
 			if (seenOutputKeys.has(key)) {

--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -317,6 +317,29 @@ function parseComponentValue(
 ): Component["value"] | undefined {
 	const type = componentType.toLowerCase();
 
+	// Scribbles are canvas annotations. Their four corners describe the text
+	// rectangle inside the slightly larger component bounds.
+	if (type === "scribble") {
+		const text = containerItems.Text;
+		const a = containerItems.Ca as { x: number; y: number } | undefined;
+		const b = containerItems.Cb as { x: number; y: number } | undefined;
+		const c = containerItems.Cc as { x: number; y: number } | undefined;
+		const d = containerItems.Cd as { x: number; y: number } | undefined;
+
+		return {
+			type: "scribble",
+			text: text === undefined ? "" : String(text),
+			font:
+				containerItems.Font === undefined
+					? "Arial"
+					: String(containerItems.Font),
+			size: Number(containerItems.Size ?? 12),
+			bold: containerItems.Bold === true,
+			italic: containerItems.Italic === true,
+			corners: a && b && c && d ? { a, b, c, d } : undefined,
+		};
+	}
+
 	// Parse Slider values
 	if (type.includes("slider")) {
 		const sliderChunk = findChunk(containerChunk, "Slider");

--- a/parser/src/types.ts
+++ b/parser/src/types.ts
@@ -94,6 +94,7 @@ export interface ComponentValue {
 	type:
 		| "slider"
 		| "panel"
+		| "scribble"
 		| "valueList"
 		| "number"
 		| "text"
@@ -108,6 +109,17 @@ export interface ComponentValue {
 	interval?: number;
 	// Panel/Text specific
 	text?: string;
+	// Scribble specific
+	font?: string;
+	size?: number;
+	bold?: boolean;
+	italic?: boolean;
+	corners?: {
+		a: { x: number; y: number };
+		b: { x: number; y: number };
+		c: { x: number; y: number };
+		d: { x: number; y: number };
+	};
 	// Value List specific
 	items?: Array<{
 		name: string;

--- a/parser/src/types.ts
+++ b/parser/src/types.ts
@@ -29,6 +29,7 @@ export interface InputPort {
 	options?: PortOptions;
 	wireStyle?: WireStyle;
 	instanceGuid: string;
+	visuals?: Visuals;
 }
 
 export interface OutputPort {
@@ -37,6 +38,7 @@ export interface OutputPort {
 	optional?: boolean;
 	options?: PortOptions;
 	instanceGuid: string;
+	visuals?: Visuals;
 }
 
 export interface Visuals {

--- a/src/app/duckerweb/components/GHButtonNode.tsx
+++ b/src/app/duckerweb/components/GHButtonNode.tsx
@@ -2,12 +2,13 @@ import type { GHButtonNodeProps } from "../types/type";
 import { GHHandle } from "./Handle";
 
 export function GHButtonNode({ data, selected }: GHButtonNodeProps) {
+	const bounded = data.usesGrasshopperBounds === true;
 	return (
 		<div
-			className={`flex h-7 items-center overflow-hidden rounded-sm border border-none bg-[#444] font-sans text-[10px] shadow-sm select-none`}
-			style={{ minWidth: 100 }}
+			className={`flex items-center overflow-hidden rounded-sm border border-none bg-[#444] font-sans text-[10px] shadow-sm select-none ${bounded ? "h-full w-full min-w-0" : "h-7"}`}
+			style={{ minWidth: bounded ? undefined : 100 }}
 		>
-			<div className="flex h-full shrink-0 items-center border-r border-[#aaa] bg-[#b0ada6] px-2 font-medium text-[#222]">
+			<div className="flex h-full max-w-[65%] shrink-0 items-center overflow-hidden border-r border-[#aaa] bg-[#b0ada6] px-2 font-medium text-ellipsis whitespace-nowrap text-[#222]">
 				{data.label ?? "Button"}
 			</div>
 

--- a/src/app/duckerweb/components/GHComponentNode.tsx
+++ b/src/app/duckerweb/components/GHComponentNode.tsx
@@ -114,7 +114,15 @@ export function GHComponentNode({ data, selected }: GHNodeProps) {
 					/>
 
 					<div
-						className={`${usesGrasshopperBounds ? "w-full overflow-hidden px-0.5" : "ml-1 min-w-0 flex-1 pr-2"} text-[10px]`}
+						className={`${usesGrasshopperBounds ? "shrink-0 overflow-hidden" : "ml-1 min-w-0 flex-1 pr-2"} text-[10px]`}
+						style={
+							usesGrasshopperBounds
+								? {
+										marginLeft: input.labelOffset ?? 0,
+										width: input.labelWidth ?? inputWidth,
+									}
+								: undefined
+						}
 					>
 						<PortLabel
 							port={input}
@@ -128,7 +136,7 @@ export function GHComponentNode({ data, selected }: GHNodeProps) {
 			{outputs.map((output, index) => (
 				<div
 					key={output.id}
-					className="pointer-events-none absolute right-0 flex items-center justify-end text-center"
+					className={`pointer-events-none absolute right-0 flex items-center text-center ${usesGrasshopperBounds ? "justify-start" : "justify-end"}`}
 					style={{
 						top: getPortTop(output, index, outputs.length),
 						width: outputWidth,
@@ -136,7 +144,15 @@ export function GHComponentNode({ data, selected }: GHNodeProps) {
 					}}
 				>
 					<div
-						className={`${usesGrasshopperBounds ? "w-full overflow-hidden px-0.5" : "mr-1 min-w-0"} text-[10px]`}
+						className={`${usesGrasshopperBounds ? "shrink-0 overflow-hidden" : "mr-1 min-w-0"} text-[10px]`}
+						style={
+							usesGrasshopperBounds
+								? {
+										marginLeft: output.labelOffset ?? 0,
+										width: output.labelWidth ?? outputWidth,
+									}
+								: undefined
+						}
 					>
 						<PortLabel
 							port={output}

--- a/src/app/duckerweb/components/GHComponentNode.tsx
+++ b/src/app/duckerweb/components/GHComponentNode.tsx
@@ -24,7 +24,10 @@ function getComputedSideWidth(ports: Port[], manualWidth?: number) {
 	);
 }
 
-function getPortTop(index: number, count: number) {
+function getPortTop(port: Port, index: number, count: number) {
+	if (port.position !== undefined) {
+		return `${port.position * 100}%`;
+	}
 	if (count <= 0) {
 		return "50%";
 	}
@@ -38,20 +41,22 @@ export function GHComponentNode({ data, selected }: GHNodeProps) {
 
 	const inputWidth = getComputedSideWidth(inputs, data.inputWidth);
 	const outputWidth = getComputedSideWidth(outputs, data.outputWidth);
+	const usesGrasshopperBounds =
+		data.inputWidth !== undefined && data.outputWidth !== undefined;
 	const palette = runtimePalette(
 		data.runtimeState ?? "normal",
 		data.accentColor
 	);
 
 	return (
-		<div className="relative overflow-visible">
+		<div className="relative h-full w-full overflow-visible">
 			<div
-				className={`relative flex overflow-hidden rounded-sm border font-sans text-[10px] shadow-md select-none ${
+				className={`relative flex h-full w-full overflow-hidden rounded-sm border font-sans text-[10px] shadow-md select-none ${
 					selected ? "border-[#444]" : "border-[#444]"
 				}`}
 			>
 				<div
-					className="flex flex-col justify-around border-r border-[#444] px-2 py-2"
+					className={`flex shrink-0 flex-col justify-around border-r border-[#444] ${usesGrasshopperBounds ? "p-0" : "px-2 py-2"}`}
 					style={{ width: inputWidth, backgroundColor: palette.side }}
 				>
 					{inputs.map((input) => (
@@ -63,7 +68,7 @@ export function GHComponentNode({ data, selected }: GHNodeProps) {
 				</div>
 
 				<div
-					className="flex items-center justify-center px-2 py-2"
+					className={`flex min-w-0 flex-1 items-center justify-center ${usesGrasshopperBounds ? "p-0" : "px-2 py-2"}`}
 					style={{ backgroundColor: palette.center }}
 				>
 					<span
@@ -78,7 +83,7 @@ export function GHComponentNode({ data, selected }: GHNodeProps) {
 				</div>
 
 				<div
-					className="flex flex-col justify-around border-l border-[#444] px-2 py-2"
+					className={`flex shrink-0 flex-col justify-around border-l border-[#444] ${usesGrasshopperBounds ? "p-0" : "px-2 py-2"}`}
 					style={{ width: outputWidth, backgroundColor: palette.side }}
 				>
 					{outputs.map((output) => (
@@ -95,7 +100,7 @@ export function GHComponentNode({ data, selected }: GHNodeProps) {
 					key={input.id}
 					className="pointer-events-none absolute left-0 flex items-center"
 					style={{
-						top: getPortTop(index, inputs.length),
+						top: getPortTop(input, index, inputs.length),
 						width: inputWidth,
 						transform: "translateY(-50%)",
 					}}
@@ -105,12 +110,15 @@ export function GHComponentNode({ data, selected }: GHNodeProps) {
 						position="left"
 						type="target"
 						id={input.id}
+						detached={usesGrasshopperBounds}
 					/>
 
-					<div className="ml-1 min-w-0 flex-1 pr-2 text-[10px]">
+					<div
+						className={`${usesGrasshopperBounds ? "w-full overflow-hidden px-0.5" : "ml-1 min-w-0 flex-1 pr-2"} text-[10px]`}
+					>
 						<PortLabel
 							port={input}
-							align="right"
+							align={usesGrasshopperBounds ? "center" : "right"}
 							style={{ color: palette.text }}
 						/>
 					</div>
@@ -122,15 +130,17 @@ export function GHComponentNode({ data, selected }: GHNodeProps) {
 					key={output.id}
 					className="pointer-events-none absolute right-0 flex items-center justify-end text-center"
 					style={{
-						top: getPortTop(index, outputs.length),
+						top: getPortTop(output, index, outputs.length),
 						width: outputWidth,
 						transform: "translateY(-50%)",
 					}}
 				>
-					<div className="mr-1 min-w-0 text-[10px]">
+					<div
+						className={`${usesGrasshopperBounds ? "w-full overflow-hidden px-0.5" : "mr-1 min-w-0"} text-[10px]`}
+					>
 						<PortLabel
 							port={output}
-							align="right"
+							align={usesGrasshopperBounds ? "center" : "right"}
 							style={{ color: palette.text }}
 						/>
 					</div>
@@ -140,6 +150,7 @@ export function GHComponentNode({ data, selected }: GHNodeProps) {
 						position="right"
 						type="source"
 						id={output.id}
+						detached={usesGrasshopperBounds}
 					/>
 				</div>
 			))}

--- a/src/app/duckerweb/components/GHFlowCanvas.tsx
+++ b/src/app/duckerweb/components/GHFlowCanvas.tsx
@@ -8,6 +8,7 @@ import {
 	Controls,
 	Panel,
 	useReactFlow,
+	useViewport,
 	type NodeTypes,
 	type EdgeTypes,
 } from "@xyflow/react";
@@ -63,6 +64,28 @@ function FocusOnNode({ focus }: { focus: GHFlowCanvasProps["focus"] }) {
 	return null;
 }
 
+function OriginAxes() {
+	const { x, y } = useViewport();
+
+	return (
+		<div
+			className="pointer-events-none absolute inset-0 z-0 overflow-hidden"
+			aria-hidden="true"
+		>
+			<div
+				data-origin-axis="x"
+				className="absolute right-0 left-0 h-0.5 -translate-y-1/2 bg-[#767873]/80"
+				style={{ top: y }}
+			/>
+			<div
+				data-origin-axis="y"
+				className="absolute top-0 bottom-0 w-0.5 -translate-x-1/2 bg-[#767873]/80"
+				style={{ left: x }}
+			/>
+		</div>
+	);
+}
+
 export function GHFlowCanvas({ nodes, edges, focus }: GHFlowCanvasProps) {
 	const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 	const [revealHiddenWires, setRevealHiddenWires] = useState(false);
@@ -116,6 +139,7 @@ export function GHFlowCanvas({ nodes, edges, focus }: GHFlowCanvasProps) {
 					bgColor="#cbc9c8"
 					color="#bbb8af"
 				/>
+				<OriginAxes />
 				<Controls />
 				<Panel position="top-right">
 					<button

--- a/src/app/duckerweb/components/GHFlowCanvas.tsx
+++ b/src/app/duckerweb/components/GHFlowCanvas.tsx
@@ -24,11 +24,13 @@ import { GHSwatchNode } from "./GHSwatchNode";
 import { GHButtonNode } from "./GHButtonNode";
 import { GHGroupNode } from "./GHGroupNode";
 import { GHRelayNode } from "./GHRelayNode";
+import { GHScribbleNode } from "./GHScribbleNode";
 import { GHEdge } from "./GHEdge";
 import type { GHFlowCanvasProps } from "../types/type";
 
 const nodeTypes: NodeTypes = {
 	panel: GHPanelNode as NodeTypes[string],
+	scribble: GHScribbleNode as NodeTypes[string],
 	value: GHPanelNode as NodeTypes[string],
 	component: GHComponentNode as NodeTypes[string],
 	script: GHScriptNode as NodeTypes[string],

--- a/src/app/duckerweb/components/GHFlowCanvas.tsx
+++ b/src/app/duckerweb/components/GHFlowCanvas.tsx
@@ -69,19 +69,13 @@ function OriginAxes() {
 
 	return (
 		<div
-			className="pointer-events-none absolute inset-0 z-0 overflow-hidden"
+			className="pointer-events-none absolute z-0 size-4 -translate-x-1/2 -translate-y-1/2"
+			data-origin-marker="true"
+			style={{ left: x, top: y }}
 			aria-hidden="true"
 		>
-			<div
-				data-origin-axis="x"
-				className="absolute right-0 left-0 h-0.5 -translate-y-1/2 bg-[#767873]/80"
-				style={{ top: y }}
-			/>
-			<div
-				data-origin-axis="y"
-				className="absolute top-0 bottom-0 w-0.5 -translate-x-1/2 bg-[#767873]/80"
-				style={{ left: x }}
-			/>
+			<div className="absolute top-1/2 right-0 left-0 h-0.5 -translate-y-1/2 bg-[#666864]/80" />
+			<div className="absolute top-0 bottom-0 left-1/2 w-0.5 -translate-x-1/2 bg-[#666864]/80" />
 		</div>
 	);
 }

--- a/src/app/duckerweb/components/GHFlowCanvas.tsx
+++ b/src/app/duckerweb/components/GHFlowCanvas.tsx
@@ -8,7 +8,6 @@ import {
 	Controls,
 	Panel,
 	useReactFlow,
-	useViewport,
 	type NodeTypes,
 	type EdgeTypes,
 } from "@xyflow/react";
@@ -64,22 +63,6 @@ function FocusOnNode({ focus }: { focus: GHFlowCanvasProps["focus"] }) {
 	return null;
 }
 
-function OriginAxes() {
-	const { x, y } = useViewport();
-
-	return (
-		<div
-			className="pointer-events-none absolute z-0 size-4 -translate-x-1/2 -translate-y-1/2"
-			data-origin-marker="true"
-			style={{ left: x, top: y }}
-			aria-hidden="true"
-		>
-			<div className="absolute top-1/2 right-0 left-0 h-0.5 -translate-y-1/2 bg-[#666864]/80" />
-			<div className="absolute top-0 bottom-0 left-1/2 w-0.5 -translate-x-1/2 bg-[#666864]/80" />
-		</div>
-	);
-}
-
 export function GHFlowCanvas({ nodes, edges, focus }: GHFlowCanvasProps) {
 	const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 	const [revealHiddenWires, setRevealHiddenWires] = useState(false);
@@ -133,7 +116,6 @@ export function GHFlowCanvas({ nodes, edges, focus }: GHFlowCanvasProps) {
 					bgColor="#cbc9c8"
 					color="#bbb8af"
 				/>
-				<OriginAxes />
 				<Controls />
 				<Panel position="top-right">
 					<button

--- a/src/app/duckerweb/components/GHGroupNode.tsx
+++ b/src/app/duckerweb/components/GHGroupNode.tsx
@@ -1,4 +1,5 @@
 import type { GHGroupNodeProps } from "../types/type";
+import { grasshopperArgbToCss } from "../lib/grasshopper-color";
 
 export function GHGroupNode({ data }: GHGroupNodeProps) {
 	const bounds = data.containerBounds;
@@ -16,6 +17,7 @@ export function GHGroupNode({ data }: GHGroupNodeProps) {
 			className="relative h-full w-full rounded-lg"
 			style={{
 				zIndex: 1,
+				backgroundColor: grasshopperArgbToCss(data.groupColor, "transparent"),
 			}}
 		>
 			{data.label !== "Group" && (

--- a/src/app/duckerweb/components/GHGroupNode.tsx
+++ b/src/app/duckerweb/components/GHGroupNode.tsx
@@ -21,9 +21,22 @@ export function GHGroupNode({ data }: GHGroupNodeProps) {
 			}}
 		>
 			{data.label !== "Group" && (
-				<span className="absolute -top-6 left-1/2 -translate-x-1/2 text-[9px] font-semibold whitespace-nowrap text-neutral-800">
-					{data.label}
-				</span>
+				<div
+					className="pointer-events-none absolute bottom-[calc(100%+5px)] left-1/2 z-20 -translate-x-1/2"
+					title={data.label}
+				>
+					<div className="relative border border-[#292929] bg-[#f4f4f4] px-2 py-1 font-sans text-[9px] leading-none font-normal whitespace-nowrap text-[#1f1f1f] shadow-sm">
+						{data.label}
+						<span
+							aria-hidden="true"
+							className="absolute top-full left-1/2 h-0 w-0 -translate-x-1/2 border-x-[6px] border-t-[8px] border-x-transparent border-t-[#292929]"
+						/>
+						<span
+							aria-hidden="true"
+							className="absolute top-full left-1/2 h-0 w-0 -translate-x-1/2 -translate-y-px border-x-[5px] border-t-[7px] border-x-transparent border-t-[#f4f4f4]"
+						/>
+					</div>
+				</div>
 			)}
 		</div>
 	);

--- a/src/app/duckerweb/components/GHPanelNode.tsx
+++ b/src/app/duckerweb/components/GHPanelNode.tsx
@@ -5,25 +5,45 @@ import { HandlePosition } from "./HandlePosition";
 export function GHPanelNode({ data }: GHNodeProps) {
 	const inputs = data.inputs ?? [];
 	const outputs = data.outputs ?? [];
+	const bounded = data.usesGrasshopperBounds === true;
+	const hasHeading = data.label.trim() !== "" && data.label !== "Panel";
+	const headingHeight = bounded ? Math.min(16, (data.height ?? 32) / 2) : 16;
+	const handleTop =
+		bounded && hasHeading && data.height
+			? `${(headingHeight / data.height) * 100}%`
+			: "50%";
 
 	return (
-		<div className="relative overflow-visible">
+		<div
+			className={`relative overflow-visible ${bounded ? "h-full w-full" : ""}`}
+		>
 			<div
-				className="relative flex items-center overflow-hidden rounded-sm border border-[#444] font-sans text-[10px] shadow-sm select-none"
+				className={`relative flex flex-col overflow-hidden rounded-sm border border-[#444] font-sans text-[10px] shadow-sm select-none ${bounded ? "h-full w-full min-w-0" : ""}`}
 				style={{
-					minWidth: 60,
-					height: data.height ?? 28,
+					minWidth: bounded ? undefined : 60,
+					height: bounded ? "100%" : (data.height ?? 28),
 					backgroundColor: "#fff",
 				}}
 			>
+				{hasHeading && (
+					<div
+						className="flex w-full shrink-0 items-center justify-center overflow-hidden border-b border-[#444] bg-[#e8e8e8] px-2 font-sans font-medium text-ellipsis whitespace-nowrap text-[#222]"
+						style={{ height: headingHeight }}
+						title={data.label}
+					>
+						{data.label}
+					</div>
+				)}
 				{data.value !== undefined && data.value !== "" && (
-					<span className="px-2 font-mono text-[10px] text-[#444]">
-						{data.value}
-					</span>
+					<div className="flex min-h-0 w-full flex-1 items-center justify-center overflow-hidden">
+						<span className="min-w-0 overflow-hidden px-2 text-center font-mono text-[10px] text-ellipsis whitespace-nowrap text-[#444]">
+							{data.value}
+						</span>
+					</div>
 				)}
 			</div>
 
-			<HandlePosition position="left">
+			<HandlePosition position="left" top={handleTop}>
 				<GHHandle
 					variant="detailed"
 					position="left"
@@ -32,7 +52,7 @@ export function GHPanelNode({ data }: GHNodeProps) {
 				/>
 			</HandlePosition>
 
-			<HandlePosition position="right">
+			<HandlePosition position="right" top={handleTop}>
 				<GHHandle
 					variant="detailed"
 					position="right"

--- a/src/app/duckerweb/components/GHRelayNode.tsx
+++ b/src/app/duckerweb/components/GHRelayNode.tsx
@@ -5,16 +5,19 @@ import { PortLabel } from "./PortOptions";
 
 export function GHRelayNode({ data, selected }: GHNodeProps) {
 	const output = data.outputs[0];
+	const bounded = data.usesGrasshopperBounds === true;
 
 	return (
-		<div className="relative overflow-visible">
+		<div
+			className={`relative overflow-visible ${bounded ? "h-full w-full" : ""}`}
+		>
 			<div
-				className={`relative flex items-center overflow-hidden rounded-sm border font-sans text-[10px] shadow-md select-none ${
+				className={`relative flex items-center overflow-hidden rounded-sm border font-sans text-[10px] shadow-md select-none ${bounded ? "h-full w-full min-w-0" : ""} ${
 					selected ? "border-[#444]" : "border-[#444]"
 				}`}
 				style={{ backgroundColor: "#E8E8E8" }}
 			>
-				<div className="px-2 py-1.5 text-[11px] font-bold tracking-tight text-[#222]">
+				<div className="min-w-0 overflow-hidden px-2 py-1.5 text-[11px] font-bold tracking-tight text-ellipsis whitespace-nowrap text-[#222]">
 					{output ? (
 						<PortLabel port={{ ...output, label: data.label }} align="left" />
 					) : (

--- a/src/app/duckerweb/components/GHScribbleNode.tsx
+++ b/src/app/duckerweb/components/GHScribbleNode.tsx
@@ -1,0 +1,40 @@
+import type { CSSProperties } from "react";
+import type { GHScribbleNodeProps } from "../types/type";
+
+export function GHScribbleNode({ data }: GHScribbleNodeProps) {
+	const scribble = data.scribble;
+	const bounds = scribble?.componentBounds;
+	const corners = scribble?.corners;
+	const textBounds =
+		bounds && corners
+			? {
+					left: corners.a.x - bounds.x,
+					top: corners.a.y - bounds.y,
+					width: corners.b.x - corners.a.x,
+					height: corners.d.y - corners.a.y,
+				}
+			: { left: 5, top: 5, width: "calc(100% - 10px)", height: "auto" };
+	const textStyle: CSSProperties = {
+		position: "absolute",
+		...textBounds,
+		fontFamily: scribble?.font ?? "Arial",
+		fontSize: scribble?.size ?? 12,
+		fontWeight: scribble?.bold ? 700 : 400,
+		fontStyle: scribble?.italic ? "italic" : "normal",
+		lineHeight:
+			typeof textBounds.height === "number"
+				? `${textBounds.height}px`
+				: "normal",
+	};
+
+	return (
+		<div className="pointer-events-none relative h-full w-full overflow-visible select-none">
+			<div
+				className="overflow-visible whitespace-pre text-[#1f1f1f]"
+				style={textStyle}
+			>
+				{data.value}
+			</div>
+		</div>
+	);
+}

--- a/src/app/duckerweb/components/GHScriptNode.tsx
+++ b/src/app/duckerweb/components/GHScriptNode.tsx
@@ -225,7 +225,15 @@ export function GHScriptNode({ data, selected }: GHNodeProps) {
 						/>
 
 						<div
-							className={`${bounded ? "w-full overflow-hidden px-0.5" : "ml-1 min-w-0 flex-1 pr-2"} text-[10px]`}
+							className={`${bounded ? "shrink-0 overflow-hidden" : "ml-1 min-w-0 flex-1 pr-2"} text-[10px]`}
+							style={
+								bounded
+									? {
+											marginLeft: input.labelOffset ?? 0,
+											width: input.labelWidth ?? inputWidth,
+										}
+									: undefined
+							}
 						>
 							<PortLabel
 								port={input}
@@ -239,7 +247,7 @@ export function GHScriptNode({ data, selected }: GHNodeProps) {
 				{outputs.map((output, index) => (
 					<div
 						key={output.id}
-						className="pointer-events-none absolute right-0 flex items-center justify-end text-center"
+						className={`pointer-events-none absolute right-0 flex items-center text-center ${bounded ? "justify-start" : "justify-end"}`}
 						style={{
 							top: getPortTop(output, index, outputs.length),
 							width: outputWidth,
@@ -247,7 +255,15 @@ export function GHScriptNode({ data, selected }: GHNodeProps) {
 						}}
 					>
 						<div
-							className={`${bounded ? "w-full overflow-hidden px-0.5" : "mr-1 min-w-0"} text-[10px]`}
+							className={`${bounded ? "shrink-0 overflow-hidden" : "mr-1 min-w-0"} text-[10px]`}
+							style={
+								bounded
+									? {
+											marginLeft: output.labelOffset ?? 0,
+											width: output.labelWidth ?? outputWidth,
+										}
+									: undefined
+							}
 						>
 							<PortLabel
 								port={output}

--- a/src/app/duckerweb/components/GHScriptNode.tsx
+++ b/src/app/duckerweb/components/GHScriptNode.tsx
@@ -32,7 +32,10 @@ function getComputedSideWidth(ports: Port[], manualWidth?: number) {
 	);
 }
 
-function getPortTop(index: number, count: number) {
+function getPortTop(port: Port, index: number, count: number) {
+	if (port.position !== undefined) {
+		return `${port.position * 100}%`;
+	}
 	if (count <= 0) {
 		return "50%";
 	}
@@ -135,6 +138,7 @@ export function GHScriptNode({ data, selected }: GHNodeProps) {
 
 	const inputWidth = getComputedSideWidth(inputs, data.inputWidth);
 	const outputWidth = getComputedSideWidth(outputs, data.outputWidth);
+	const bounded = data.usesGrasshopperBounds === true;
 	const palette = runtimePalette(
 		data.runtimeState ?? "normal",
 		data.accentColor
@@ -142,14 +146,16 @@ export function GHScriptNode({ data, selected }: GHNodeProps) {
 
 	return (
 		<>
-			<div className="relative overflow-visible">
+			<div
+				className={`relative overflow-visible ${bounded ? "h-full w-full" : ""}`}
+			>
 				<div
-					className={`relative flex overflow-hidden rounded-sm border font-sans text-[10px] shadow-md select-none ${
+					className={`relative flex overflow-hidden rounded-sm border font-sans text-[10px] shadow-md select-none ${bounded ? "h-full w-full" : ""} ${
 						selected ? "border-[#444]" : "border-[#444]"
 					}`}
 				>
 					<div
-						className="flex flex-col justify-around border-r border-[#444] px-2 py-2"
+						className={`flex shrink-0 flex-col justify-around border-r border-[#444] ${bounded ? "p-0" : "px-2 py-2"}`}
 						style={{ width: inputWidth, backgroundColor: palette.side }}
 					>
 						{inputs.map((input) => (
@@ -161,7 +167,7 @@ export function GHScriptNode({ data, selected }: GHNodeProps) {
 					</div>
 
 					<div
-						className="flex items-center justify-center px-2 py-2"
+						className={`flex min-w-0 flex-1 items-center justify-center ${bounded ? "p-0" : "px-2 py-2"}`}
 						style={{ backgroundColor: palette.center }}
 					>
 						<span
@@ -176,7 +182,7 @@ export function GHScriptNode({ data, selected }: GHNodeProps) {
 					</div>
 
 					<div
-						className="flex flex-col justify-around border-l border-[#444] px-2 py-2"
+						className={`flex shrink-0 flex-col justify-around border-l border-[#444] ${bounded ? "p-0" : "px-2 py-2"}`}
 						style={{ width: outputWidth, backgroundColor: palette.side }}
 					>
 						{outputs.map((output) => (
@@ -205,7 +211,7 @@ export function GHScriptNode({ data, selected }: GHNodeProps) {
 						key={input.id}
 						className="pointer-events-none absolute left-0 flex items-center"
 						style={{
-							top: getPortTop(index, inputs.length),
+							top: getPortTop(input, index, inputs.length),
 							width: inputWidth,
 							transform: "translateY(-50%)",
 						}}
@@ -215,12 +221,15 @@ export function GHScriptNode({ data, selected }: GHNodeProps) {
 							position="left"
 							type="target"
 							id={input.id}
+							detached={bounded}
 						/>
 
-						<div className="ml-1 min-w-0 flex-1 pr-2 text-[10px]">
+						<div
+							className={`${bounded ? "w-full overflow-hidden px-0.5" : "ml-1 min-w-0 flex-1 pr-2"} text-[10px]`}
+						>
 							<PortLabel
 								port={input}
-								align="right"
+								align={bounded ? "center" : "right"}
 								style={{ color: palette.text }}
 							/>
 						</div>
@@ -232,15 +241,17 @@ export function GHScriptNode({ data, selected }: GHNodeProps) {
 						key={output.id}
 						className="pointer-events-none absolute right-0 flex items-center justify-end text-center"
 						style={{
-							top: getPortTop(index, outputs.length),
+							top: getPortTop(output, index, outputs.length),
 							width: outputWidth,
 							transform: "translateY(-50%)",
 						}}
 					>
-						<div className="mr-1 min-w-0 text-[10px]">
+						<div
+							className={`${bounded ? "w-full overflow-hidden px-0.5" : "mr-1 min-w-0"} text-[10px]`}
+						>
 							<PortLabel
 								port={output}
-								align="right"
+								align={bounded ? "center" : "right"}
 								style={{ color: palette.text }}
 							/>
 						</div>
@@ -250,6 +261,7 @@ export function GHScriptNode({ data, selected }: GHNodeProps) {
 							position="right"
 							type="source"
 							id={output.id}
+							detached={bounded}
 						/>
 					</div>
 				))}

--- a/src/app/duckerweb/components/GHSliderNode.tsx
+++ b/src/app/duckerweb/components/GHSliderNode.tsx
@@ -1,19 +1,20 @@
 import type { GHSliderNodeProps } from "../types/type";
 import { GHHandle } from "./Handle";
 
-export function GHSliderNode({ data, selected }: GHSliderNodeProps) {
+export function GHSliderNode({ data }: GHSliderNodeProps) {
 	const percent = data.percent ?? 50;
+	const bounded = data.usesGrasshopperBounds === true;
 
 	return (
 		<div
-			className={`flex h-7 items-center overflow-hidden rounded-sm border bg-[#c8c5be] font-sans text-[10px] shadow-sm select-none ${selected ? "border-[#00a0ff]" : "border-[#999990]"} `}
-			style={{ minWidth: 200 }}
+			className={`flex items-center overflow-hidden rounded-sm border border-[#444] bg-[#c8c5be] font-sans text-[10px] shadow-sm select-none ${bounded ? "h-full w-full min-w-0" : "h-7"}`}
+			style={{ minWidth: bounded ? undefined : 200 }}
 		>
-			<div className="flex h-full shrink-0 items-center border-r border-[#aaa] bg-[#b0ada6] px-2 py-2 font-medium text-[#222]">
+			<div className="flex h-full max-w-[45%] shrink-0 items-center overflow-hidden border-r border-[#444] bg-[#b0ada6] px-2 py-2 font-medium text-ellipsis whitespace-nowrap text-[#222]">
 				{data.label ?? "Slider"}
 			</div>
 
-			<div className="flex h-full flex-1 items-center gap-1 bg-[#d8d5ce] px-2 py-2">
+			<div className="flex h-full min-w-0 flex-1 items-center gap-1 bg-[#d8d5ce] px-2 py-2">
 				<div className="relative h-[2px] flex-1 bg-[#aaa]">
 					<div
 						className="absolute top-1/2 h-4 w-2 -translate-y-1/2 cursor-ew-resize border border-[#666] bg-[#888]"

--- a/src/app/duckerweb/components/GHSwatchNode.tsx
+++ b/src/app/duckerweb/components/GHSwatchNode.tsx
@@ -1,31 +1,29 @@
 import type { GHSwatchNodeProps } from "../types/type";
+import { grasshopperArgbToCss } from "../lib/grasshopper-color";
 import { GHHandle } from "./Handle";
 
-function semicolonRgbaToCss(input: string): string {
-	const parts = input.split(";").map(Number);
-
-	if (parts.length < 3 || parts.some(Number.isNaN)) {
-		return "#ddd";
-	}
-
-	const [a = 255, r, g, b] = parts;
-	const alpha = Math.max(0, Math.min(255, a)) / 255;
-
-	return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
 export function GHSwatchNode({ data }: GHSwatchNodeProps) {
-	const bg = data.color ? semicolonRgbaToCss(data.color) : "#ddd";
+	const bg = grasshopperArgbToCss(data.color, "#ddd");
+	const bounded = data.usesGrasshopperBounds === true;
 	return (
-		<div className="relative overflow-visible">
-			<div className="flex h-7 w-max items-center overflow-hidden rounded-sm border border-[#444] font-sans text-[10px] shadow-md select-none">
-				<div className="flex h-full min-w-11 items-center border-r border-[#444] bg-[#b0ada6] px-2 font-medium whitespace-nowrap text-[#222]">
+		<div
+			className={`relative overflow-visible ${bounded ? "h-full w-full" : ""}`}
+		>
+			<div
+				className={`flex items-center overflow-hidden rounded-sm border border-[#444] font-sans text-[10px] shadow-md select-none ${bounded ? "h-full w-full min-w-0" : "h-7 w-max"}`}
+			>
+				<div
+					className={`flex h-full min-w-0 items-center overflow-hidden border-r border-[#444] bg-[#b0ada6] px-2 font-medium text-ellipsis whitespace-nowrap text-[#222] ${bounded ? "flex-1" : "min-w-11"}`}
+				>
 					{data.label ?? "Swatch"}
 				</div>
 				<div
 					aria-hidden
-					className="h-full w-14 shrink-0"
-					style={{ backgroundColor: bg }}
+					className={`h-full shrink-0 ${bounded ? "" : "w-14"}`}
+					style={{
+						backgroundColor: bg,
+						width: bounded ? (data.outputWidth ?? "25%") : undefined,
+					}}
 				/>
 			</div>
 

--- a/src/app/duckerweb/components/GHToggleNode.tsx
+++ b/src/app/duckerweb/components/GHToggleNode.tsx
@@ -2,17 +2,18 @@ import type { GHToggleNodeProps } from "../types/type";
 import { GHHandle } from "./Handle";
 
 export function GHToggleNode({ data, selected }: GHToggleNodeProps) {
+	const bounded = data.usesGrasshopperBounds === true;
 	return (
 		<div
-			className={`flex h-7 items-center overflow-hidden rounded-sm border border-none bg-[#c8c5be] font-sans text-[10px] shadow-sm select-none`}
-			style={{ minWidth: 80 }}
+			className={`flex items-center overflow-hidden rounded-sm border border-none bg-[#c8c5be] font-sans text-[10px] shadow-sm select-none ${bounded ? "h-full w-full min-w-0" : "h-7"}`}
+			style={{ minWidth: bounded ? undefined : 80 }}
 		>
-			<div className="flex h-full shrink-0 items-center border-r border-[#aaa] bg-[#b0ada6] px-2 font-medium text-[#222]">
+			<div className="flex h-full max-w-[55%] shrink-0 items-center overflow-hidden border-r border-[#aaa] bg-[#b0ada6] px-2 font-medium text-ellipsis whitespace-nowrap text-[#222]">
 				{data.label ?? "Toggle"}
 			</div>
 
-			<div className="flex h-full flex-1 items-center justify-center bg-[#444] px-3">
-				<span className="font-mono text-[11px] text-[#ddd]">
+			<div className="flex h-full min-w-0 flex-1 items-center justify-center overflow-hidden bg-[#444] px-3">
+				<span className="overflow-hidden font-mono text-[11px] text-ellipsis whitespace-nowrap text-[#ddd]">
 					{data.value ?? "False"}
 				</span>
 			</div>

--- a/src/app/duckerweb/components/GHValueListNode.tsx
+++ b/src/app/duckerweb/components/GHValueListNode.tsx
@@ -4,23 +4,26 @@ import { HandlePosition } from "./HandlePosition";
 
 export function GHValueListNode({ data, selected }: GHValueListNodeProps) {
 	const outputs = data.outputs ?? [];
+	const bounded = data.usesGrasshopperBounds === true;
 
 	return (
-		<div className="relative overflow-visible">
+		<div
+			className={`relative overflow-visible ${bounded ? "h-full w-full" : ""}`}
+		>
 			<div
-				className={`relative flex items-center overflow-hidden rounded-sm border font-sans text-[10px] shadow-sm select-none ${selected ? "border-[#444]" : "border-[#444]"}`}
+				className={`relative flex items-center overflow-hidden rounded-sm border font-sans text-[10px] shadow-sm select-none ${bounded ? "h-full w-full min-w-0" : ""} ${selected ? "border-[#444]" : "border-[#444]"}`}
 				style={{
-					minWidth: 100,
-					height: data.value ? 28 : 24,
+					minWidth: bounded ? undefined : 100,
+					height: bounded ? "100%" : data.value ? 28 : 24,
 					backgroundColor: "#fff",
 				}}
 			>
-				<div className="flex shrink-0 items-center border-r border-[#ddd] bg-[#f5f5f0] px-2 font-medium text-[#444]">
+				<div className="flex max-w-[55%] min-w-0 shrink-0 items-center overflow-hidden border-r border-[#ddd] bg-[#f5f5f0] px-2 font-medium text-ellipsis whitespace-nowrap text-[#444]">
 					{data.label}
 				</div>
 
-				<div className="flex flex-1 items-center justify-between px-2">
-					<span className="font-mono text-[10px] text-[#333]">
+				<div className="flex min-w-0 flex-1 items-center justify-between px-2">
+					<span className="min-w-0 overflow-hidden font-mono text-[10px] text-ellipsis whitespace-nowrap text-[#333]">
 						{data.value ?? ""}
 					</span>
 					<span className="text-[8px] text-[#999]">▾</span>

--- a/src/app/duckerweb/components/Handle.tsx
+++ b/src/app/duckerweb/components/Handle.tsx
@@ -8,6 +8,7 @@ export function GHHandle({
 	type,
 	id,
 	className = "",
+	detached = false,
 }: GHHandleProps) {
 	if (variant === "compact") {
 		return (
@@ -25,15 +26,20 @@ export function GHHandle({
 	}
 
 	const borderRadius = type === "target" ? "50%" : "80%";
-	const transform =
-		position === "left" ? "translateX(-50%)" : "translateX(50%)";
+	const transform = detached
+		? position === "left"
+			? "translate(-50%, -50%)"
+			: "translate(50%, -50%)"
+		: position === "left"
+			? "translateX(-50%)"
+			: "translateX(50%)";
 
 	return (
 		<Handle
 			type={type}
 			position={position === "left" ? Position.Left : Position.Right}
 			id={id}
-			className={`pointer-events-auto relative! top-auto! left-auto! translate-x-0! translate-y-0! ${className}`}
+			className={`pointer-events-auto ${detached ? "" : "relative! top-auto! left-auto! translate-x-0! translate-y-0!"} ${className}`}
 			style={{
 				width: HANDLE_SIZE,
 				height: HANDLE_SIZE,

--- a/src/app/duckerweb/components/HandlePosition.tsx
+++ b/src/app/duckerweb/components/HandlePosition.tsx
@@ -4,13 +4,14 @@ export function HandlePosition({
 	position,
 	children,
 	className = "",
+	top = "50%",
 }: GHHandlePositionProps) {
 	const isLeft = position === "left";
 
 	return (
 		<div
 			className={`pointer-events-none absolute flex items-center ${isLeft ? "left-0" : "right-0 justify-end"} ${className}`}
-			style={{ top: "50%", transform: "translateY(-50%)" }}
+			style={{ top, transform: "translateY(-50%)" }}
 		>
 			{children}
 		</div>

--- a/src/app/duckerweb/components/PortOptions.tsx
+++ b/src/app/duckerweb/components/PortOptions.tsx
@@ -124,7 +124,7 @@ export function PortLabel({
 	style,
 }: {
 	port: Port;
-	align: "left" | "right";
+	align: "left" | "center" | "right";
 	style?: CSSProperties;
 }) {
 	const badges = getOptionBadges(port.options);
@@ -133,7 +133,11 @@ export function PortLabel({
 	return (
 		<span
 			className={`pointer-events-auto flex w-full min-w-0 items-center gap-1 whitespace-nowrap ${
-				align === "right" ? "justify-end text-right" : "justify-start text-left"
+				align === "right"
+					? "justify-end text-right"
+					: align === "center"
+						? "justify-center text-center"
+						: "justify-start text-left"
 			}`}
 			style={style}
 			title={summary}

--- a/src/app/duckerweb/components/PortOptions.tsx
+++ b/src/app/duckerweb/components/PortOptions.tsx
@@ -132,7 +132,7 @@ export function PortLabel({
 
 	return (
 		<span
-			className={`pointer-events-auto flex w-full min-w-0 items-center gap-1 whitespace-nowrap ${
+			className={`pointer-events-auto flex w-full min-w-0 items-center gap-1 leading-none whitespace-nowrap ${
 				align === "right"
 					? "justify-end text-right"
 					: align === "center"

--- a/src/app/duckerweb/components/constants.ts
+++ b/src/app/duckerweb/components/constants.ts
@@ -1,3 +1,2 @@
 export const HANDLE_SIZE = 10;
 export const HANDLE_STROKE = "#444";
-export const POSITION_SCALE_X = 1.25;

--- a/src/app/duckerweb/gh-flow-generator.test.ts
+++ b/src/app/duckerweb/gh-flow-generator.test.ts
@@ -1,7 +1,156 @@
 import { expect, test } from "vitest";
 import fs from "node:fs";
 import { buildGhJson } from "parser/src/parser";
+import type { Component, ParsedGrasshopper } from "parser/src/types";
 import { generateFlowData } from "./gh-flow-generator";
+import { grasshopperArgbToCss } from "./lib/grasshopper-color";
+
+function component(
+	id: string,
+	type: string,
+	bounds: { x: number; y: number; width: number; height: number },
+	inputs: Component["inputs"] = {},
+	outputs: Component["outputs"] = {}
+): Component {
+	return {
+		id,
+		type,
+		typeGuid: `${id}-type`,
+		instanceGuid: `${id}-instance`,
+		nickName: id,
+		inputs,
+		outputs,
+		visuals: { bounds },
+	};
+}
+
+test("generateFlowData preserves Grasshopper bounds for nodes and groups", () => {
+	const division = component(
+		"A/B",
+		"Division",
+		{ x: 80, y: 492, width: 55, height: 44 },
+		{
+			a: {
+				nick: "A",
+				instanceGuid: "division-a",
+				visuals: {
+					bounds: { x: 82, y: 494, width: 9, height: 20 },
+					pivot: { x: 88, y: 504 },
+				},
+			},
+			b: {
+				nick: "B",
+				instanceGuid: "division-b",
+				visuals: {
+					bounds: { x: 82, y: 514, width: 9, height: 20 },
+					pivot: { x: 88, y: 524 },
+				},
+			},
+		},
+		{
+			result: {
+				nick: "R",
+				instanceGuid: "division-result",
+				visuals: {
+					bounds: { x: 121, y: 494, width: 12, height: 40 },
+					pivot: { x: 127, y: 514 },
+				},
+			},
+		}
+	);
+	const sphere = component(
+		"MSphere",
+		"Mesh Sphere",
+		{ x: 155, y: 502, width: 58, height: 84 },
+		{
+			base: {
+				nick: "B",
+				instanceGuid: "sphere-base",
+				source: "A/B.result",
+				visuals: {
+					bounds: { x: 157, y: 504, width: 10, height: 20 },
+					pivot: { x: 163.5, y: 514 },
+				},
+			},
+			radius: {
+				nick: "R",
+				instanceGuid: "sphere-radius",
+				visuals: {
+					bounds: { x: 157, y: 524, width: 10, height: 20 },
+					pivot: { x: 163.5, y: 534 },
+				},
+			},
+			u: {
+				nick: "U",
+				instanceGuid: "sphere-u",
+				visuals: {
+					bounds: { x: 157, y: 544, width: 10, height: 20 },
+					pivot: { x: 163.5, y: 554 },
+				},
+			},
+			v: {
+				nick: "V",
+				instanceGuid: "sphere-v",
+				visuals: {
+					bounds: { x: 157, y: 564, width: 10, height: 20 },
+					pivot: { x: 163.5, y: 574 },
+				},
+			},
+		},
+		{
+			mesh: {
+				nick: "M",
+				instanceGuid: "sphere-mesh",
+				visuals: {
+					bounds: { x: 197, y: 504, width: 14, height: 80 },
+					pivot: { x: 204, y: 544 },
+				},
+			},
+		}
+	);
+	const group: Component = {
+		...component("Group", "Group", { x: 0, y: 0, width: 0, height: 0 }),
+		visuals: { color: "150;135;50;50" },
+		members: [division.id, sphere.id],
+	};
+	const parsed: ParsedGrasshopper = {
+		version: "0.2.2",
+		components: { division, sphere, group },
+		wires: [{ from: "A/B.result", to: "MSphere.base" }],
+	};
+
+	const { nodes } = generateFlowData(parsed);
+	const divisionNode = nodes.find((node) => node.id === division.id);
+	const sphereNode = nodes.find((node) => node.id === sphere.id);
+	const groupNode = nodes.find((node) => node.id === group.id);
+
+	expect(divisionNode?.position).toEqual({ x: 80, y: 492 });
+	expect(divisionNode?.style).toMatchObject({ width: 55, height: 44 });
+	expect(sphereNode?.position).toEqual({ x: 155, y: 502 });
+	expect(sphereNode?.style).toMatchObject({ width: 58, height: 84 });
+	expect(sphereNode?.data).toMatchObject({
+		inputWidth: 12,
+		outputWidth: 16,
+		usesGrasshopperBounds: true,
+	});
+	expect(sphereNode?.data.inputs.map((port) => port.position)).toEqual([
+		12 / 84,
+		32 / 84,
+		52 / 84,
+		72 / 84,
+	]);
+	expect(sphereNode?.data.outputs[0]?.position).toBe(42 / 84);
+	expect(groupNode?.position).toEqual({ x: 70, y: 482 });
+	expect(groupNode?.style).toMatchObject({ width: 153, height: 114 });
+	expect(groupNode?.data.groupColor).toBe("150;135;50;50");
+});
+
+test("Grasshopper ARGB colors retain their encoded opacity", () => {
+	expect(grasshopperArgbToCss("150;135;50;50", "transparent")).toBe(
+		"rgba(135, 50, 50, 0.5882352941176471)"
+	);
+	expect(grasshopperArgbToCss("invalid", "transparent")).toBe("transparent");
+});
 
 test("generateFlowData maps wires onto connected source/target nodes", () => {
 	const xml = fs.readFileSync("parser/sand/xmls/brep-area-Wire.xml", "utf8");

--- a/src/app/duckerweb/gh-flow-generator.test.ts
+++ b/src/app/duckerweb/gh-flow-generator.test.ts
@@ -152,6 +152,55 @@ test("Grasshopper ARGB colors retain their encoded opacity", () => {
 	expect(grasshopperArgbToCss("invalid", "transparent")).toBe("transparent");
 });
 
+test("generateFlowData renders Scribble as positioned text annotation", () => {
+	const scribble = component("Scribble", "Scribble", {
+		x: 655,
+		y: 15,
+		width: 468.26172,
+		height: 26.892578,
+	});
+	scribble.value = {
+		type: "scribble",
+		text: "Sinuous interlocking seam — native GH components only",
+		font: "Arial",
+		size: 18,
+		bold: false,
+		italic: false,
+		corners: {
+			a: { x: 660, y: 20 },
+			b: { x: 1118.2617, y: 20 },
+			c: { x: 1118.2617, y: 36.89258 },
+			d: { x: 660, y: 36.89258 },
+		},
+	};
+
+	const { nodes } = generateFlowData({
+		version: "0.2.2",
+		components: { scribble },
+		wires: [],
+	});
+	const node = nodes[0];
+
+	expect(node.type).toBe("scribble");
+	expect(node.position).toEqual({ x: 655, y: 15 });
+	expect(node.style).toMatchObject({ width: 468.26172, height: 26.892578 });
+	expect(node.data.value).toBe(
+		"Sinuous interlocking seam — native GH components only"
+	);
+	expect(node.data.scribble).toMatchObject({
+		font: "Arial",
+		size: 18,
+		bold: false,
+		italic: false,
+		componentBounds: {
+			x: 655,
+			y: 15,
+			width: 468.26172,
+			height: 26.892578,
+		},
+	});
+});
+
 test("generateFlowData maps wires onto connected source/target nodes", () => {
 	const xml = fs.readFileSync("parser/sand/xmls/brep-area-Wire.xml", "utf8");
 	const parsed = buildGhJson(xml, { includeVisuals: true });

--- a/src/app/duckerweb/gh-flow-generator.test.ts
+++ b/src/app/duckerweb/gh-flow-generator.test.ts
@@ -139,7 +139,15 @@ test("generateFlowData preserves Grasshopper bounds for nodes and groups", () =>
 		52 / 84,
 		72 / 84,
 	]);
+	expect(sphereNode?.data.inputs[0]).toMatchObject({
+		labelOffset: 2,
+		labelWidth: 10,
+	});
 	expect(sphereNode?.data.outputs[0]?.position).toBe(42 / 84);
+	expect(sphereNode?.data.outputs[0]).toMatchObject({
+		labelOffset: 0,
+		labelWidth: 14,
+	});
 	expect(groupNode?.position).toEqual({ x: 70, y: 482 });
 	expect(groupNode?.style).toMatchObject({ width: 153, height: 114 });
 	expect(groupNode?.data.groupColor).toBe("150;135;50;50");

--- a/src/app/duckerweb/lib/component-handler.ts
+++ b/src/app/duckerweb/lib/component-handler.ts
@@ -53,12 +53,19 @@ export function handleComponent(
 ): GHNode {
 	const inputPorts = Object.values(component.inputs);
 	const outputPorts = Object.values(component.outputs);
+	const inputWidth = getPortColumnWidth(component, inputPorts, "input");
+	const outputWidth = getPortColumnWidth(component, outputPorts, "output");
 	const inputs = Object.entries(component.inputs).map(([key, port]) => ({
 		id: `${component.id}.${key}`,
 		label: port.nick,
 		options: port.options,
 		hasSource: !!port.source,
 		position: getRelativePortPosition(component, port),
+		labelOffset:
+			component.visuals?.bounds && port.visuals?.bounds
+				? port.visuals.bounds.x - component.visuals.bounds.x
+				: undefined,
+		labelWidth: port.visuals?.bounds?.width,
 	}));
 
 	const outputEntries = Object.entries(component.outputs);
@@ -74,6 +81,16 @@ export function handleComponent(
 					}
 				: port.options,
 		position: getRelativePortPosition(component, port),
+		labelOffset:
+			component.visuals?.bounds &&
+			port.visuals?.bounds &&
+			outputWidth !== undefined
+				? port.visuals.bounds.x -
+					(component.visuals.bounds.x +
+						component.visuals.bounds.width -
+						outputWidth)
+				: undefined,
+		labelWidth: port.visuals?.bounds?.width,
 	}));
 
 	const position = nodePositions.get(component.id) ?? {
@@ -98,8 +115,8 @@ export function handleComponent(
 					: "normal",
 		value: extractValue(component),
 		height: position.height,
-		inputWidth: getPortColumnWidth(component, inputPorts, "input"),
-		outputWidth: getPortColumnWidth(component, outputPorts, "output"),
+		inputWidth,
+		outputWidth,
 		usesGrasshopperBounds: component.visuals?.bounds !== undefined,
 	};
 	const runtimeClasses = [

--- a/src/app/duckerweb/lib/component-handler.ts
+++ b/src/app/duckerweb/lib/component-handler.ts
@@ -4,16 +4,61 @@ import type { NodePosition } from "./node-positions";
 import { getAccentColor } from "./node-classifier";
 import { extractValue } from "./value-extractor";
 
+function getRelativePortPosition(
+	component: Component,
+	port: Component["inputs"][string] | Component["outputs"][string]
+): number | undefined {
+	const componentBounds = component.visuals?.bounds;
+	if (!componentBounds || componentBounds.height <= 0) return undefined;
+
+	const portY =
+		port.visuals?.pivot?.y ??
+		(port.visuals?.bounds
+			? port.visuals.bounds.y + port.visuals.bounds.height / 2
+			: undefined);
+	if (portY === undefined) return undefined;
+
+	return Math.max(
+		0,
+		Math.min(1, (portY - componentBounds.y) / componentBounds.height)
+	);
+}
+
+function getPortColumnWidth(
+	component: Component,
+	ports: Array<Component["inputs"][string] | Component["outputs"][string]>,
+	side: "input" | "output"
+): number | undefined {
+	const componentBounds = component.visuals?.bounds;
+	if (!componentBounds) return undefined;
+	if (ports.length === 0) return 0;
+
+	const bounds = ports.map((port) => port.visuals?.bounds);
+	if (bounds.some((candidate) => !candidate)) return undefined;
+	const portBounds = bounds.filter((candidate) => candidate !== undefined);
+
+	return side === "input"
+		? Math.max(
+				...portBounds.map((candidate) => candidate.x + candidate.width)
+			) - componentBounds.x
+		: componentBounds.x +
+				componentBounds.width -
+				Math.min(...portBounds.map((candidate) => candidate.x));
+}
+
 export function handleComponent(
 	component: Component,
 	nodePositions: Map<string, NodePosition>,
 	nodeType: GHNodeType
 ): GHNode {
+	const inputPorts = Object.values(component.inputs);
+	const outputPorts = Object.values(component.outputs);
 	const inputs = Object.entries(component.inputs).map(([key, port]) => ({
 		id: `${component.id}.${key}`,
 		label: port.nick,
 		options: port.options,
 		hasSource: !!port.source,
+		position: getRelativePortPosition(component, port),
 	}));
 
 	const outputEntries = Object.entries(component.outputs);
@@ -28,6 +73,7 @@ export function handleComponent(
 							port.options?.expression ?? component.internalExpression,
 					}
 				: port.options,
+		position: getRelativePortPosition(component, port),
 	}));
 
 	const position = nodePositions.get(component.id) ?? {
@@ -52,6 +98,9 @@ export function handleComponent(
 					: "normal",
 		value: extractValue(component),
 		height: position.height,
+		inputWidth: getPortColumnWidth(component, inputPorts, "input"),
+		outputWidth: getPortColumnWidth(component, outputPorts, "output"),
+		usesGrasshopperBounds: component.visuals?.bounds !== undefined,
 	};
 	const runtimeClasses = [
 		component.state?.hidden && "gh-runtime-node--hidden",
@@ -75,7 +124,8 @@ export function handleComponent(
 	return {
 		id: component.id,
 		type: nodeType,
-		position,
+		position: { x: position.x, y: position.y },
+		style: { width: position.width, height: position.height },
 		data: nodeData,
 		className: runtimeClasses.join(" "),
 		zIndex: 10,

--- a/src/app/duckerweb/lib/component-handler.ts
+++ b/src/app/duckerweb/lib/component-handler.ts
@@ -117,6 +117,17 @@ export function handleComponent(
 		nodeData.color = component.value.color;
 	}
 
+	if (component.value?.type === "scribble") {
+		nodeData.scribble = {
+			font: component.value.font ?? "Arial",
+			size: component.value.size ?? 12,
+			bold: component.value.bold === true,
+			italic: component.value.italic === true,
+			corners: component.value.corners,
+			componentBounds: component.visuals?.bounds,
+		};
+	}
+
 	if (component.script) {
 		nodeData.script = component.script;
 	}

--- a/src/app/duckerweb/lib/grasshopper-color.ts
+++ b/src/app/duckerweb/lib/grasshopper-color.ts
@@ -1,0 +1,20 @@
+export function grasshopperArgbToCss(
+	argb: string | undefined,
+	fallback: string
+): string {
+	if (!argb) return fallback;
+
+	const channels = argb.split(";").map(Number);
+	if (
+		channels.length !== 4 ||
+		channels.some((channel) => !Number.isFinite(channel))
+	) {
+		return fallback;
+	}
+
+	const [alpha, red, green, blue] = channels.map((channel) =>
+		Math.max(0, Math.min(255, channel))
+	);
+
+	return `rgba(${red}, ${green}, ${blue}, ${alpha / 255})`;
+}

--- a/src/app/duckerweb/lib/group-handler.ts
+++ b/src/app/duckerweb/lib/group-handler.ts
@@ -1,19 +1,13 @@
 import type { Component } from "parser/src/types";
 import type { GHNode, GHNodeData } from "../types/type";
 import type { NodePosition } from "./node-positions";
-import { POSITION_SCALE_X } from "../components/constants";
 
 export function handleGroup(
 	component: Component,
 	nodePositions: Map<string, NodePosition>
 ): GHNode {
 	const bounds = component.visuals?.bounds
-		? {
-				x: component.visuals.bounds.x * POSITION_SCALE_X,
-				y: component.visuals.bounds.y,
-				width: component.visuals.bounds.width * POSITION_SCALE_X,
-				height: component.visuals.bounds.height,
-			}
+		? component.visuals.bounds
 		: computeGroupBounds(component.members ?? [], nodePositions);
 
 	const nodeData: GHNodeData = {
@@ -23,6 +17,7 @@ export function handleGroup(
 		outputs: [],
 		selected: component.state?.selected,
 		members: component.members,
+		groupColor: component.visuals?.color,
 		containerBounds: bounds.width > 0 && bounds.height > 0 ? bounds : undefined,
 	};
 
@@ -50,7 +45,7 @@ function computeGroupBounds(
 	members: string[],
 	nodePositions: Map<string, NodePosition>
 ): { x: number; y: number; width: number; height: number } {
-	const PAD = 12;
+	const padding = 10;
 	const memberBounds = members
 		.map((id) => nodePositions.get(id) ?? null)
 		.filter((b): b is NonNullable<typeof b> => b !== null);
@@ -61,14 +56,10 @@ function computeGroupBounds(
 	const rights = memberBounds.map((b) => b.x + b.width);
 	const bottoms = memberBounds.map((b) => b.y + b.height);
 
-	const RIGHT_EXTRA = 30;
-	const SINGLE_HEIGHT_BONUS = memberBounds.length === 1 ? PAD : 0;
-
 	return {
-		x: Math.min(...xs) - PAD,
-		y: Math.min(...ys) - PAD,
-		width: Math.max(...rights) - Math.min(...xs) + PAD * 2 + RIGHT_EXTRA,
-		height:
-			Math.max(...bottoms) - Math.min(...ys) + PAD * 2 + SINGLE_HEIGHT_BONUS,
+		x: Math.min(...xs) - padding,
+		y: Math.min(...ys) - padding,
+		width: Math.max(...rights) - Math.min(...xs) + padding * 2,
+		height: Math.max(...bottoms) - Math.min(...ys) + padding * 2,
 	};
 }

--- a/src/app/duckerweb/lib/node-classifier.ts
+++ b/src/app/duckerweb/lib/node-classifier.ts
@@ -4,6 +4,7 @@ import type { GHNodeType } from "../types/type";
 export function getComponentNodeType(component: Component): GHNodeType {
 	if (component.type === "Group") return "group";
 	if (component.type.endsWith("Script")) return "script";
+	if (component.value?.type === "scribble") return "scribble";
 	if (component.value?.type === "slider") return "slider";
 	if (component.value?.type === "valueList") return "valueList";
 	if (component.value?.type === "toggle") return "toggle";

--- a/src/app/duckerweb/lib/node-positions.ts
+++ b/src/app/duckerweb/lib/node-positions.ts
@@ -1,5 +1,4 @@
 import type { Component } from "parser/src/types";
-import { POSITION_SCALE_X } from "../components/constants";
 
 export type NodePosition = {
 	x: number;
@@ -18,9 +17,9 @@ export function buildNodePositions(
 		const b = comp.visuals?.bounds;
 		if (b) {
 			nodePositions.set(comp.id, {
-				x: b.x * POSITION_SCALE_X,
+				x: b.x,
 				y: b.y,
-				width: b.width * POSITION_SCALE_X,
+				width: b.width,
 				height: b.height,
 			});
 		} else {

--- a/src/app/duckerweb/lib/value-extractor.ts
+++ b/src/app/duckerweb/lib/value-extractor.ts
@@ -9,6 +9,7 @@ export function extractValue(component: Component): string | undefined {
 		case "slider":
 			return v.current !== undefined ? String(v.current) : undefined;
 		case "panel":
+		case "scribble":
 		case "text":
 			return v.text ?? undefined;
 		case "valueList":

--- a/src/app/duckerweb/types/type.ts
+++ b/src/app/duckerweb/types/type.ts
@@ -44,6 +44,8 @@ export type Port = {
 	label: string;
 	options?: PortOptions;
 	position?: number;
+	labelOffset?: number;
+	labelWidth?: number;
 };
 
 export type Bounds = {

--- a/src/app/duckerweb/types/type.ts
+++ b/src/app/duckerweb/types/type.ts
@@ -26,9 +26,13 @@ export type GHNodeData = {
 	runtimeState?: GHRuntimeState;
 	members?: string[];
 	containerBounds?: Bounds;
+	groupColor?: string;
 	value?: string;
 	percent?: number;
 	height?: number;
+	inputWidth?: number;
+	outputWidth?: number;
+	usesGrasshopperBounds?: boolean;
 } & Record<string, unknown>;
 
 export type GHNode = Node<GHNodeData>;
@@ -37,6 +41,7 @@ export type Port = {
 	id: string;
 	label: string;
 	options?: PortOptions;
+	position?: number;
 };
 
 export type Bounds = {
@@ -167,6 +172,7 @@ export type GHNodeProps = {
 		value?: string;
 		height?: number;
 		script?: ScriptData;
+		usesGrasshopperBounds?: boolean;
 	};
 	selected?: boolean;
 };
@@ -177,6 +183,7 @@ export type GHGroupNodeProps = {
 		type: string;
 		members?: string[];
 		containerBounds?: Bounds;
+		groupColor?: string;
 		accentColor?: string;
 		selected?: boolean;
 	};
@@ -193,6 +200,7 @@ export type GHSliderNodeProps = {
 		selected?: boolean;
 		value?: string;
 		percent?: number;
+		usesGrasshopperBounds?: boolean;
 	};
 	selected?: boolean;
 };
@@ -214,6 +222,7 @@ export type GHValueListNodeProps = {
 		value?: string;
 		items?: GHValueListItem[];
 		selectedIndex?: number;
+		usesGrasshopperBounds?: boolean;
 	};
 	selected?: boolean;
 };
@@ -227,6 +236,7 @@ export type GHToggleNodeProps = {
 		accentColor?: string;
 		selected?: boolean;
 		value?: string;
+		usesGrasshopperBounds?: boolean;
 	};
 	selected?: boolean;
 };
@@ -241,6 +251,8 @@ export type GHSwatchNodeProps = {
 		selected?: boolean;
 		value?: string;
 		color?: string;
+		outputWidth?: number;
+		usesGrasshopperBounds?: boolean;
 	};
 	selected?: boolean;
 };
@@ -253,6 +265,7 @@ export type GHButtonNodeProps = {
 		outputs: Port[];
 		accentColor?: string;
 		selected?: boolean;
+		usesGrasshopperBounds?: boolean;
 	};
 	selected?: boolean;
 };
@@ -282,10 +295,12 @@ export type GHHandleProps = {
 	type: HandlePortType;
 	id?: string;
 	className?: string;
+	detached?: boolean;
 };
 
 export type GHHandlePositionProps = {
 	position: HandleSide;
 	children: ReactNode;
 	className?: string;
+	top?: string;
 };

--- a/src/app/duckerweb/types/type.ts
+++ b/src/app/duckerweb/types/type.ts
@@ -6,6 +6,7 @@ import type { GHRuntimeState } from "../lib/runtime-palette";
 export type GHNodeType =
 	| "value"
 	| "panel"
+	| "scribble"
 	| "component"
 	| "script"
 	| "slider"
@@ -33,6 +34,7 @@ export type GHNodeData = {
 	inputWidth?: number;
 	outputWidth?: number;
 	usesGrasshopperBounds?: boolean;
+	scribble?: GHScribbleData;
 } & Record<string, unknown>;
 
 export type GHNode = Node<GHNodeData>;
@@ -156,6 +158,27 @@ export type ScriptData = {
 	language?: string;
 	code: string;
 	title?: string;
+};
+
+export type GHScribbleData = {
+	font: string;
+	size: number;
+	bold: boolean;
+	italic: boolean;
+	corners?: {
+		a: { x: number; y: number };
+		b: { x: number; y: number };
+		c: { x: number; y: number };
+		d: { x: number; y: number };
+	};
+	componentBounds?: Bounds;
+};
+
+export type GHScribbleNodeProps = {
+	data: {
+		value?: string;
+		scribble?: GHScribbleData;
+	};
 };
 
 export type GHNodeProps = {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -129,12 +129,17 @@
 		@apply h-full w-full;
 	}
 
-	.react-flow__node.group,
-	.react-flow__node.group > div {
+	.react-flow__node-group {
 		padding: 0 !important;
 		border: 1px solid #bbb !important;
 		box-shadow: none !important;
 		background: transparent !important;
+	}
+
+	.react-flow__node-group > div {
+		padding: 0 !important;
+		border: 0 !important;
+		box-shadow: none !important;
 	}
 
 	.react-flow__edges {


### PR DESCRIPTION
## Summary

- render flow nodes from their raw Grasshopper XML bounds and remove `POSITION_SCALE`
- align component columns, labels, and sockets with parameter bounds and pivots
- center input/output names inside each parameter’s own XML bounds
- preserve specialized node dimensions and match slider/swatch strokes
- honor Grasshopper group ARGB colors and show renamed groups as attached callout labels
- render custom Panel nicknames as title headings with divider-aligned handles
- preserve numeric Panel `UserText` as text
- render Scribble annotations from `Text`, font metadata, and `Ca…Cd` text geometry without component chrome

## Verification

- `pnpm test -- --run parser/src/parser.test.ts src/app/duckerweb/gh-flow-generator.test.ts` (47 tests)
- `pnpm check`
- `pnpm build`
- live canvas comparison against the supplied Grasshopper XML and screenshots