### PR TITLE
Add optional type GUID matching for Grasshopper diffs

### DIFF
--- a/src/app/duckerweb/components/GHDiffView.tsx
+++ b/src/app/duckerweb/components/GHDiffView.tsx
@@ -9,6 +9,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import type {
+	GHDiffMatchMode,
 	GHDiffResult,
 	GHDiffStatus,
 	GHFlowCanvasFocus,
@@ -25,6 +26,9 @@ type GHDiffViewProps = {
 	originalFileName: string;
 	comparisonFileName: string;
 	comparisonRejected: boolean;
+	matchByTypeGuid: boolean;
+	diffFellBackToType: boolean;
+	onMatchByTypeGuidChange: (enabled: boolean) => void;
 };
 
 type DiffFilter = Exclude<GHDiffStatus, "unchanged"> | "layout" | "connections";
@@ -55,6 +59,53 @@ const statusStyles: Record<
 		dot: "bg-red-400",
 	},
 };
+
+function matchModeLabel(
+	mode: GHDiffMatchMode,
+	options?: { fellBack?: boolean; preferredType?: boolean }
+) {
+	if (mode === "type") {
+		if (options?.preferredType) return "matched by type GUID";
+		if (options?.fellBack) return "matched by type GUID (auto)";
+		return "matched by type GUID";
+	}
+	return "matched by instance ID";
+}
+
+function MatchModeToggle({
+	enabled,
+	onChange,
+}: {
+	enabled: boolean;
+	onChange: (enabled: boolean) => void;
+}) {
+	return (
+		<label className="inline-flex cursor-pointer items-center gap-2 text-xs text-neutral-400">
+			<span
+				className={cn(
+					"relative h-5 w-9 rounded-full border transition-colors",
+					enabled
+						? "border-yellow-400/40 bg-yellow-400/20"
+						: "border-neutral-700 bg-neutral-900"
+				)}
+			>
+				<input
+					type="checkbox"
+					checked={enabled}
+					onChange={(event) => onChange(event.target.checked)}
+					className="peer sr-only"
+				/>
+				<span
+					className={cn(
+						"absolute top-0.5 left-0.5 h-3.5 w-3.5 rounded-full bg-neutral-400 transition-transform",
+						enabled && "translate-x-4 bg-yellow-300"
+					)}
+				/>
+			</span>
+			Match by type GUID
+		</label>
+	);
+}
 
 export function ComparisonActions({
 	onPaste,
@@ -115,6 +166,9 @@ export function GHDiffView({
 	originalFileName,
 	comparisonFileName,
 	comparisonRejected,
+	matchByTypeGuid,
+	diffFellBackToType,
+	onMatchByTypeGuidChange,
 }: GHDiffViewProps) {
 	const [focus, setFocus] = useState<GHFlowCanvasFocus | null>(null);
 	const [filter, setFilter] = useState<DiffFilter | null>(null);
@@ -161,6 +215,17 @@ export function GHDiffView({
 							change.
 						</p>
 					)}
+					<div className="mt-5 flex justify-center">
+						<MatchModeToggle
+							enabled={matchByTypeGuid}
+							onChange={onMatchByTypeGuidChange}
+						/>
+					</div>
+					<p className="mx-auto mt-2 max-w-md text-xs leading-5 text-neutral-600">
+						Use type GUID matching when components were newly placed but still
+						do the same work. Instance matching falls back to type GUID
+						automatically when overlap is too low.
+					</p>
 					<div className="mt-6 flex justify-center">
 						<ComparisonActions
 							onPaste={onPasteComparison}
@@ -256,11 +321,19 @@ export function GHDiffView({
 							{comparisonFileName}
 						</span>
 						<span className="ml-2 text-neutral-600">
-							· matched by instance ID
+							·{" "}
+							{matchModeLabel(diff.matchMode, {
+								fellBack: diffFellBackToType,
+								preferredType: matchByTypeGuid,
+							})}
 						</span>
 					</p>
 				</div>
-				<div className="flex flex-wrap items-center gap-2">
+				<div className="flex flex-wrap items-center gap-3">
+					<MatchModeToggle
+						enabled={matchByTypeGuid}
+						onChange={onMatchByTypeGuidChange}
+					/>
 					<ComparisonActions
 						onPaste={onPasteComparison}
 						onFileSelected={onFileSelected}
@@ -342,7 +415,14 @@ export function GHDiffView({
 			</div>
 
 			{error && (
-				<p className="rounded-lg border border-red-900/60 bg-red-950/40 px-4 py-3 text-sm font-medium text-red-300">
+				<p
+					className={cn(
+						"rounded-lg border px-4 py-3 text-sm font-medium",
+						diffFellBackToType
+							? "border-blue-900/60 bg-blue-950/40 text-blue-200"
+							: "border-red-900/60 bg-red-950/40 text-red-300"
+					)}
+				>
 					{error}
 				</p>
 			)}

--- a/src/app/duckerweb/components/GHDiffView.tsx
+++ b/src/app/duckerweb/components/GHDiffView.tsx
@@ -27,7 +27,7 @@ type GHDiffViewProps = {
 	comparisonFileName: string;
 	comparisonRejected: boolean;
 	matchByTypeGuid: boolean;
-	diffFellBackToType: boolean;
+	diffNotice: string;
 	onMatchByTypeGuidChange: (enabled: boolean) => void;
 };
 
@@ -60,16 +60,12 @@ const statusStyles: Record<
 	},
 };
 
-function matchModeLabel(
-	mode: GHDiffMatchMode,
-	options?: { fellBack?: boolean; preferredType?: boolean }
-) {
-	if (mode === "type") {
-		if (options?.preferredType) return "matched by type GUID";
-		if (options?.fellBack) return "matched by type GUID (auto)";
-		return "matched by type GUID";
-	}
-	return "matched by instance ID";
+function matchModeLabel(mode: GHDiffMatchMode, requestedTypeGuid: boolean) {
+	if (mode !== "type") return "matched by instance ID";
+	// Type matching without the toggle on means the diff auto-fell back to it.
+	return requestedTypeGuid
+		? "matched by type GUID"
+		: "matched by type GUID (auto)";
 }
 
 function MatchModeToggle({
@@ -167,7 +163,7 @@ export function GHDiffView({
 	comparisonFileName,
 	comparisonRejected,
 	matchByTypeGuid,
-	diffFellBackToType,
+	diffNotice,
 	onMatchByTypeGuidChange,
 }: GHDiffViewProps) {
 	const [focus, setFocus] = useState<GHFlowCanvasFocus | null>(null);
@@ -321,11 +317,7 @@ export function GHDiffView({
 							{comparisonFileName}
 						</span>
 						<span className="ml-2 text-neutral-600">
-							·{" "}
-							{matchModeLabel(diff.matchMode, {
-								fellBack: diffFellBackToType,
-								preferredType: matchByTypeGuid,
-							})}
+							· {matchModeLabel(diff.matchMode, matchByTypeGuid)}
 						</span>
 					</p>
 				</div>
@@ -414,15 +406,14 @@ export function GHDiffView({
 				</button>
 			</div>
 
+			{diffNotice && (
+				<p className="rounded-lg border border-blue-900/60 bg-blue-950/40 px-4 py-3 text-sm font-medium text-blue-200">
+					{diffNotice}
+				</p>
+			)}
+
 			{error && (
-				<p
-					className={cn(
-						"rounded-lg border px-4 py-3 text-sm font-medium",
-						diffFellBackToType
-							? "border-blue-900/60 bg-blue-950/40 text-blue-200"
-							: "border-red-900/60 bg-red-950/40 text-red-300"
-					)}
-				>
+				<p className="rounded-lg border border-red-900/60 bg-red-950/40 px-4 py-3 text-sm font-medium text-red-300">
 					{error}
 				</p>
 			)}

--- a/src/app/duckerweb/gh-diff.test.ts
+++ b/src/app/duckerweb/gh-diff.test.ts
@@ -7,6 +7,7 @@ import {
 	diffGrasshopper,
 	resolveDiffComparison,
 } from "./gh-diff";
+import { NEWLY_PLACED_CHANGE } from "./lib/gh-diff/component-diff";
 
 function fixture(path: string): ParsedGrasshopper {
 	return buildGhJson(fs.readFileSync(path, "utf8"), {
@@ -204,6 +205,7 @@ describe("diffGrasshopper", () => {
 		const before = fixture("parser/sand/xmls/brep-area-Wire.xml");
 		const after = clone(before);
 		const component = Object.values(after.components)[0];
+		const previousNick = component.nickName;
 		component.nickName = `${component.nickName} revised`;
 		component.state = { ...component.state, locked: !component.state?.locked };
 
@@ -212,7 +214,10 @@ describe("diffGrasshopper", () => {
 			(item) => item.key === component.instanceGuid
 		);
 
-		expect(modified?.changes).toEqual(["Component details", "Locked"]);
+		expect(modified?.changes).toEqual([
+			`Nickname ${previousNick} → ${component.nickName}`,
+			"Locked",
+		]);
 	});
 
 	test("reports rewiring independently from component changes", () => {
@@ -286,7 +291,14 @@ describe("diffGrasshopper", () => {
 		expect(diff.matchMode).toBe("type");
 		expect(diff.counts.added).toBe(0);
 		expect(diff.counts.removed).toBe(0);
-		expect(diff.counts.modified).toBe(0);
+		expect(diff.counts.modified).toBe(Object.keys(before.components).length);
+		expect(
+			diff.components
+				.filter((component) => component.status === "modified")
+				.every((component) =>
+					component.changes.includes(NEWLY_PLACED_CHANGE)
+				)
+		).toBe(true);
 		expect(diff.addedWires).toBe(0);
 		expect(diff.removedWires).toBe(0);
 	});
@@ -304,8 +316,36 @@ describe("diffGrasshopper", () => {
 		expect(resolution.result?.matchMode).toBe("type");
 		expect(resolution.result?.counts.added).toBe(0);
 		expect(resolution.result?.counts.removed).toBe(0);
+		expect(resolution.result?.counts.modified).toBe(
+			Object.keys(before.components).length
+		);
+		expect(
+			resolution.result?.components.every((component) =>
+				component.changes.includes(NEWLY_PLACED_CHANGE)
+			)
+		).toBe(true);
 		expect(resolution.result?.addedWires).toBe(0);
 		expect(resolution.result?.removedWires).toBe(0);
+	});
+
+	test("lists newly placed note alongside other type-matched changes", () => {
+		const before = fixture("parser/sand/xmls/slider.xml");
+		const after = clone(before);
+		reinstanceAll(after, "placed");
+		const slider = Object.values(after.components).find(
+			(component) => component.value?.type === "slider"
+		);
+		expect(slider?.value).toBeDefined();
+		if (!slider?.value) return;
+		slider.value.current = (slider.value.current ?? 0) + 1;
+
+		const diff = diffGrasshopper(before, after, "type");
+		const modified = diff.components.find(
+			(component) => component.changes.includes("Value")
+		);
+
+		expect(modified?.changes[0]).toBe(NEWLY_PLACED_CHANGE);
+		expect(modified?.changes).toContain("Value");
 	});
 
 	test("still rejects when neither instance nor type GUID overlap is enough", () => {

--- a/src/app/duckerweb/gh-diff.test.ts
+++ b/src/app/duckerweb/gh-diff.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs";
 import { buildGhJson } from "parser/src/parser";
 import type { ParsedGrasshopper } from "parser/src/types";
 import { describe, expect, test } from "vitest";
-import { assessDefinitionOverlap, diffGrasshopper } from "./gh-diff";
+import {
+	assessDefinitionOverlap,
+	diffGrasshopper,
+	resolveDiffComparison,
+} from "./gh-diff";
 
 function fixture(path: string): ParsedGrasshopper {
 	return buildGhJson(fs.readFileSync(path, "utf8"), {
@@ -14,12 +18,55 @@ function clone(parsed: ParsedGrasshopper): ParsedGrasshopper {
 	return structuredClone(parsed);
 }
 
+function reinstanceAll(definition: ParsedGrasshopper, prefix: string) {
+	const inputPortIds = new Set(
+		Object.values(definition.components).flatMap((component) =>
+			Object.values(component.inputs).map((port) => port.instanceGuid)
+		)
+	);
+	const outputPortIds = new Set(
+		Object.values(definition.components).flatMap((component) =>
+			Object.values(component.outputs).map((port) => port.instanceGuid)
+		)
+	);
+	const componentIds = new Set(
+		Object.values(definition.components).map(
+			(component) => component.instanceGuid || component.id
+		)
+	);
+	for (const component of Object.values(definition.components)) {
+		component.instanceGuid = `${prefix}-${component.instanceGuid}`;
+		for (const port of Object.values(component.inputs)) {
+			port.instanceGuid = `${prefix}-in-${port.instanceGuid}`;
+		}
+		for (const port of Object.values(component.outputs)) {
+			port.instanceGuid = `${prefix}-out-${port.instanceGuid}`;
+		}
+	}
+	for (const wire of definition.wires) {
+		if (wire.sourceComponentGuid) {
+			if (outputPortIds.has(wire.sourceComponentGuid)) {
+				wire.sourceComponentGuid = `${prefix}-out-${wire.sourceComponentGuid}`;
+			} else if (componentIds.has(wire.sourceComponentGuid)) {
+				wire.sourceComponentGuid = `${prefix}-${wire.sourceComponentGuid}`;
+			}
+		}
+		if (wire.targetPortGuid) {
+			const portPrefix = inputPortIds.has(wire.targetPortGuid)
+				? `${prefix}-in-`
+				: `${prefix}-out-`;
+			wire.targetPortGuid = `${portPrefix}${wire.targetPortGuid}`;
+		}
+	}
+}
+
 describe("diffGrasshopper", () => {
 	test("rejects definitions with less than 25% component overlap", () => {
 		const before = fixture("parser/sand/xmls/brep-area-Wire.xml");
 		const after = clone(before);
 		for (const component of Object.values(after.components)) {
 			component.instanceGuid = `different-${component.instanceGuid}`;
+			component.typeGuid = `other-type-${component.typeGuid}`;
 		}
 
 		const overlap = assessDefinitionOverlap(before, after);
@@ -92,6 +139,7 @@ describe("diffGrasshopper", () => {
 		expect(diff.counts.added).toBe(0);
 		expect(diff.counts.removed).toBe(0);
 		expect(diff.layoutMoves).toBe(1);
+		expect(diff.matchMode).toBe("instance");
 	});
 
 	test("reports parameter changes as modified logic", () => {
@@ -222,5 +270,56 @@ describe("diffGrasshopper", () => {
 
 		expect(diff.counts.added).toBe(1);
 		expect(diff.counts.removed).toBe(1);
+	});
+
+	test("matches newly placed components by type GUID when asked", () => {
+		const before = fixture("parser/sand/xmls/brep-area-Wire.xml");
+		const after = clone(before);
+		reinstanceAll(after, "placed");
+
+		const instanceOverlap = assessDefinitionOverlap(before, after, "instance");
+		const typeOverlap = assessDefinitionOverlap(before, after, "type");
+		const diff = diffGrasshopper(before, after, "type");
+
+		expect(instanceOverlap.isComparable).toBe(false);
+		expect(typeOverlap.isComparable).toBe(true);
+		expect(diff.matchMode).toBe("type");
+		expect(diff.counts.added).toBe(0);
+		expect(diff.counts.removed).toBe(0);
+		expect(diff.counts.modified).toBe(0);
+		expect(diff.addedWires).toBe(0);
+		expect(diff.removedWires).toBe(0);
+	});
+
+	test("auto-falls back to type GUID matching when instance overlap is too low", () => {
+		const before = fixture("parser/sand/xmls/brep-area-Wire.xml");
+		const after = clone(before);
+		reinstanceAll(after, "placed");
+
+		const resolution = resolveDiffComparison(before, after, "instance");
+
+		expect(resolution.fellBackToType).toBe(true);
+		expect(resolution.matchMode).toBe("type");
+		expect(resolution.result).not.toBeNull();
+		expect(resolution.result?.matchMode).toBe("type");
+		expect(resolution.result?.counts.added).toBe(0);
+		expect(resolution.result?.counts.removed).toBe(0);
+		expect(resolution.result?.addedWires).toBe(0);
+		expect(resolution.result?.removedWires).toBe(0);
+	});
+
+	test("still rejects when neither instance nor type GUID overlap is enough", () => {
+		const before = fixture("parser/sand/xmls/brep-area-Wire.xml");
+		const after = clone(before);
+		reinstanceAll(after, "placed");
+		for (const component of Object.values(after.components)) {
+			component.typeGuid = `other-type-${component.typeGuid}`;
+			component.type = `Other${component.type}`;
+		}
+
+		const resolution = resolveDiffComparison(before, after, "instance");
+
+		expect(resolution.result).toBeNull();
+		expect(resolution.failedTypeOverlap?.isComparable).toBe(false);
 	});
 });

--- a/src/app/duckerweb/gh-diff.test.ts
+++ b/src/app/duckerweb/gh-diff.test.ts
@@ -422,6 +422,54 @@ describe("diffGrasshopper", () => {
 		);
 	});
 
+	test("never drops a port when a reused GUID would collide", () => {
+		const before = fixture("parser/sand/xmls/brep-area-Wire.xml");
+		const after = clone(before);
+		const beforeArea = Object.values(before.components).find(
+			(component) => Object.keys(component.inputs).length === 1
+		);
+		const afterArea = Object.values(after.components).find(
+			(component) => component.id === beforeArea?.id
+		);
+		expect(beforeArea).toBeDefined();
+		if (!beforeArea || !afterArea) return;
+
+		// The component was re-placed, so it pairs by type. Its surviving port is
+		// renamed while a newly gained port reuses the old port's GUID: re-keying
+		// the renamed port would collide and silently drop the gained one.
+		const [portKey] = Object.keys(afterArea.inputs);
+		const reusedGuid = afterArea.inputs[portKey].instanceGuid;
+		afterArea.instanceGuid = "freshly-placed";
+		afterArea.inputs[portKey] = {
+			...afterArea.inputs[portKey],
+			nick: "Renamed",
+			instanceGuid: "freshly-placed-port",
+		};
+		afterArea.inputs.extra = {
+			...beforeArea.inputs[portKey],
+			nick: "Extra",
+			instanceGuid: reusedGuid,
+		};
+
+		const diff = diffGrasshopper(before, after, "type");
+		const area = diff.components.find(
+			(component) => component.key === beforeArea.instanceGuid
+		);
+
+		// Both after-side ports stay visible: the one holding the reused GUID reads
+		// as a rename, the other is reported as gained.
+		expect(
+			area?.changes.some((change) =>
+				change.startsWith("Input Extra: Renamed G → Extra")
+			)
+		).toBe(true);
+		expect(area?.changes).toContain("Input Renamed added");
+		expect(
+			new Set(Object.values(afterArea.inputs).map((port) => port.instanceGuid))
+				.size
+		).toBe(Object.keys(afterArea.inputs).length);
+	});
+
 	test("still rejects when neither instance nor type GUID overlap is enough", () => {
 		const before = fixture("parser/sand/xmls/brep-area-Wire.xml");
 		const after = clone(before);

--- a/src/app/duckerweb/gh-diff.test.ts
+++ b/src/app/duckerweb/gh-diff.test.ts
@@ -295,9 +295,7 @@ describe("diffGrasshopper", () => {
 		expect(
 			diff.components
 				.filter((component) => component.status === "modified")
-				.every((component) =>
-					component.changes.includes(NEWLY_PLACED_CHANGE)
-				)
+				.every((component) => component.changes.includes(NEWLY_PLACED_CHANGE))
 		).toBe(true);
 		expect(diff.addedWires).toBe(0);
 		expect(diff.removedWires).toBe(0);
@@ -340,12 +338,88 @@ describe("diffGrasshopper", () => {
 		slider.value.current = (slider.value.current ?? 0) + 1;
 
 		const diff = diffGrasshopper(before, after, "type");
-		const modified = diff.components.find(
-			(component) => component.changes.includes("Value")
+		const modified = diff.components.find((component) =>
+			component.changes.includes("Value")
 		);
 
 		expect(modified?.changes[0]).toBe(NEWLY_PLACED_CHANGE);
 		expect(modified?.changes).toContain("Value");
+	});
+
+	test("keeps surviving instances paired with themselves in type mode", () => {
+		const before = fixture("parser/sand/xmls/multi-groups.xml");
+		const byType = new Map<string, string[]>();
+		for (const component of Object.values(before.components)) {
+			byType.set(component.typeGuid, [
+				...(byType.get(component.typeGuid) ?? []),
+				component.instanceGuid,
+			]);
+		}
+		const twins = [...byType.values()].find((guids) => guids.length >= 2);
+		expect(twins).toBeDefined();
+		if (!twins) return;
+
+		// Two same-type components keep their instance GUIDs but swap nicknames.
+		// Pairing must not cross them over just because the nicknames line up.
+		const [firstGuid, secondGuid] = twins;
+		const findIn = (definition: ParsedGrasshopper, guid: string) =>
+			Object.values(definition.components).find(
+				(component) => component.instanceGuid === guid
+			);
+		const beforeFirst = findIn(before, firstGuid);
+		const beforeSecond = findIn(before, secondGuid);
+		if (!beforeFirst || !beforeSecond) return;
+		beforeFirst.nickName = "alpha";
+		beforeSecond.nickName = "beta";
+
+		const after = clone(before);
+		const afterFirst = findIn(after, firstGuid);
+		const afterSecond = findIn(after, secondGuid);
+		if (!afterFirst || !afterSecond) return;
+		afterFirst.nickName = "beta";
+		afterSecond.nickName = "alpha";
+
+		const diff = diffGrasshopper(before, after, "type");
+		const changed = diff.components.filter(
+			(component) => component.status !== "unchanged"
+		);
+
+		expect(changed.map((component) => component.key).sort()).toEqual(
+			[firstGuid, secondGuid].sort()
+		);
+		expect(
+			changed.every(
+				(component) => !component.changes.includes(NEWLY_PLACED_CHANGE)
+			)
+		).toBe(true);
+		expect(changed.flatMap((component) => component.changes).sort()).toEqual([
+			"Nickname alpha → beta",
+			"Nickname beta → alpha",
+		]);
+	});
+
+	test("never drops a component when a reused GUID would collide", () => {
+		const before = fixture("parser/sand/xmls/brep-area-Wire.xml");
+		const after = clone(before);
+		const [firstBefore, secondBefore] = Object.values(before.components);
+		const [firstAfter, secondAfter] = Object.values(after.components);
+		// The after side has no counterpart for the first component's type, yet it
+		// reuses the second component's GUID. Re-keying the second pair onto that
+		// GUID would collide and silently drop one of the two from the diff.
+		firstAfter.typeGuid = "unrelated-type";
+		firstAfter.type = "UnrelatedType";
+		firstAfter.instanceGuid = secondBefore.instanceGuid;
+		secondAfter.instanceGuid = "freshly-placed";
+
+		const diff = diffGrasshopper(before, after, "type");
+
+		expect(diff.components.map((item) => item.key).sort()).toEqual(
+			[
+				firstBefore.instanceGuid,
+				secondBefore.instanceGuid,
+				"freshly-placed",
+			].sort()
+		);
 	});
 
 	test("still rejects when neither instance nor type GUID overlap is enough", () => {

--- a/src/app/duckerweb/gh-diff.ts
+++ b/src/app/duckerweb/gh-diff.ts
@@ -51,22 +51,39 @@ function overlapFromCounts(
 	};
 }
 
-export function assessDefinitionOverlap(
+type AlignedDefinitions = ReturnType<typeof alignDefinitionsForMatchMode>;
+
+/**
+ * Aligning is the expensive half of a comparison (it clones and re-keys the
+ * after side), so overlap and the diff itself always share a single pass.
+ */
+function alignForMode(
 	beforeDefinition: ParsedGrasshopper,
 	afterDefinition: ParsedGrasshopper,
-	matchMode: DiffMatchMode = "instance"
-): DefinitionOverlap {
+	matchMode: DiffMatchMode
+): { aligned: AlignedDefinitions; overlap: DefinitionOverlap } {
 	const aligned = alignDefinitionsForMatchMode(
 		beforeDefinition,
 		afterDefinition,
 		matchMode
 	);
-	return overlapFromCounts(
-		aligned.matchedCount,
-		Object.keys(beforeDefinition.components).length,
-		Object.keys(afterDefinition.components).length,
-		matchMode
-	);
+	return {
+		aligned,
+		overlap: overlapFromCounts(
+			aligned.matchedCount,
+			Object.keys(beforeDefinition.components).length,
+			Object.keys(afterDefinition.components).length,
+			matchMode
+		),
+	};
+}
+
+export function assessDefinitionOverlap(
+	beforeDefinition: ParsedGrasshopper,
+	afterDefinition: ParsedGrasshopper,
+	matchMode: DiffMatchMode = "instance"
+): DefinitionOverlap {
+	return alignForMode(beforeDefinition, afterDefinition, matchMode).overlap;
 }
 
 function countStatuses(
@@ -83,16 +100,10 @@ function countStatuses(
 	return counts;
 }
 
-export function diffGrasshopper(
-	beforeDefinition: ParsedGrasshopper,
-	afterDefinition: ParsedGrasshopper,
-	matchMode: DiffMatchMode = "instance"
+function diffFromAlignment(
+	aligned: AlignedDefinitions,
+	matchMode: DiffMatchMode
 ): GHDiffResult {
-	const aligned = alignDefinitionsForMatchMode(
-		beforeDefinition,
-		afterDefinition,
-		matchMode
-	);
 	const before = indexDefinition(aligned.before);
 	const after = indexDefinition(aligned.after);
 	const componentDiff = diffComponents(
@@ -110,6 +121,17 @@ export function diffGrasshopper(
 	};
 }
 
+export function diffGrasshopper(
+	beforeDefinition: ParsedGrasshopper,
+	afterDefinition: ParsedGrasshopper,
+	matchMode: DiffMatchMode = "instance"
+): GHDiffResult {
+	return diffFromAlignment(
+		alignDefinitionsForMatchMode(beforeDefinition, afterDefinition, matchMode),
+		matchMode
+	);
+}
+
 /**
  * Resolve a comparison using the preferred match mode. When preferring
  * instance IDs, automatically fall back to type GUID matching if instance
@@ -120,50 +142,42 @@ export function resolveDiffComparison(
 	afterDefinition: ParsedGrasshopper,
 	preferredMode: DiffMatchMode = "instance"
 ): DiffComparisonResolution {
-	const preferredOverlap = assessDefinitionOverlap(
+	const preferred = alignForMode(
 		beforeDefinition,
 		afterDefinition,
 		preferredMode
 	);
-	if (preferredOverlap.isComparable) {
+	if (preferred.overlap.isComparable) {
 		return {
-			overlap: preferredOverlap,
+			overlap: preferred.overlap,
 			matchMode: preferredMode,
 			fellBackToType: false,
-			result: diffGrasshopper(
-				beforeDefinition,
-				afterDefinition,
-				preferredMode
-			),
+			result: diffFromAlignment(preferred.aligned, preferredMode),
 		};
 	}
 
 	if (preferredMode === "instance") {
-		const typeOverlap = assessDefinitionOverlap(
-			beforeDefinition,
-			afterDefinition,
-			"type"
-		);
-		if (typeOverlap.isComparable) {
+		const byType = alignForMode(beforeDefinition, afterDefinition, "type");
+		if (byType.overlap.isComparable) {
 			return {
-				overlap: typeOverlap,
+				overlap: byType.overlap,
 				matchMode: "type",
 				fellBackToType: true,
-				result: diffGrasshopper(beforeDefinition, afterDefinition, "type"),
+				result: diffFromAlignment(byType.aligned, "type"),
 			};
 		}
 
 		return {
-			overlap: preferredOverlap,
+			overlap: preferred.overlap,
 			matchMode: preferredMode,
 			fellBackToType: false,
 			result: null,
-			failedTypeOverlap: typeOverlap,
+			failedTypeOverlap: byType.overlap,
 		};
 	}
 
 	return {
-		overlap: preferredOverlap,
+		overlap: preferred.overlap,
 		matchMode: preferredMode,
 		fellBackToType: false,
 		result: null,
@@ -174,8 +188,7 @@ export function formatOverlapRejection(
 	overlap: DefinitionOverlap,
 	failedTypeOverlap?: DefinitionOverlap
 ): string {
-	const modeLabel =
-		overlap.matchMode === "type" ? "type GUID" : "instance ID";
+	const modeLabel = overlap.matchMode === "type" ? "type GUID" : "instance ID";
 	const base = `Only ${Math.round(overlap.ratio * 100)}% component overlap (${overlap.matchedCount} of ${overlap.smallerCount} matched by ${modeLabel}). Ducker requires at least 25% overlap${overlap.smallerCount > 5 ? " and 3 matched components" : ""}.`;
 	if (failedTypeOverlap) {
 		return `${base} Type GUID matching also fell short (${Math.round(failedTypeOverlap.ratio * 100)}% overlap, ${failedTypeOverlap.matchedCount} of ${failedTypeOverlap.smallerCount}).`;

--- a/src/app/duckerweb/gh-diff.ts
+++ b/src/app/duckerweb/gh-diff.ts
@@ -2,7 +2,13 @@ import type { ParsedGrasshopper } from "parser/src/types";
 import { diffComponents } from "./lib/gh-diff/component-diff";
 import { indexDefinition } from "./lib/gh-diff/definition-index";
 import { buildGraphOverlay } from "./lib/gh-diff/graph-overlay";
+import {
+	alignDefinitionsForMatchMode,
+	type DiffMatchMode,
+} from "./lib/gh-diff/match-align";
 import type { GHDiffResult, GHDiffStatus } from "./types/type";
+
+export type { DiffMatchMode };
 
 const MIN_COMPONENT_OVERLAP = 0.25;
 const MIN_MATCHES_FOR_LARGE_DEFINITION = 3;
@@ -12,21 +18,24 @@ export type DefinitionOverlap = {
 	smallerCount: number;
 	ratio: number;
 	isComparable: boolean;
+	matchMode: DiffMatchMode;
 };
 
-export function assessDefinitionOverlap(
-	beforeDefinition: ParsedGrasshopper,
-	afterDefinition: ParsedGrasshopper
+export type DiffComparisonResolution = {
+	overlap: DefinitionOverlap;
+	matchMode: DiffMatchMode;
+	fellBackToType: boolean;
+	result: GHDiffResult | null;
+	failedTypeOverlap?: DefinitionOverlap;
+};
+
+function overlapFromCounts(
+	matchedCount: number,
+	beforeCount: number,
+	afterCount: number,
+	matchMode: DiffMatchMode
 ): DefinitionOverlap {
-	const before = indexDefinition(beforeDefinition);
-	const after = indexDefinition(afterDefinition);
-	const smallerCount = Math.min(
-		before.componentsByKey.size,
-		after.componentsByKey.size
-	);
-	const matchedCount = [...before.componentsByKey.keys()].filter((key) =>
-		after.componentsByKey.has(key)
-	).length;
+	const smallerCount = Math.min(beforeCount, afterCount);
 	// With no components on one side there is no identity evidence with which
 	// to reject the comparison. Treat it as a valid all-added/all-removed diff.
 	const ratio = smallerCount === 0 ? 1 : matchedCount / smallerCount;
@@ -38,7 +47,26 @@ export function assessDefinitionOverlap(
 		smallerCount,
 		ratio,
 		isComparable: ratio >= MIN_COMPONENT_OVERLAP && enoughMatches,
+		matchMode,
 	};
+}
+
+export function assessDefinitionOverlap(
+	beforeDefinition: ParsedGrasshopper,
+	afterDefinition: ParsedGrasshopper,
+	matchMode: DiffMatchMode = "instance"
+): DefinitionOverlap {
+	const aligned = alignDefinitionsForMatchMode(
+		beforeDefinition,
+		afterDefinition,
+		matchMode
+	);
+	return overlapFromCounts(
+		aligned.matchedCount,
+		Object.keys(beforeDefinition.components).length,
+		Object.keys(afterDefinition.components).length,
+		matchMode
+	);
 }
 
 function countStatuses(
@@ -57,10 +85,16 @@ function countStatuses(
 
 export function diffGrasshopper(
 	beforeDefinition: ParsedGrasshopper,
-	afterDefinition: ParsedGrasshopper
+	afterDefinition: ParsedGrasshopper,
+	matchMode: DiffMatchMode = "instance"
 ): GHDiffResult {
-	const before = indexDefinition(beforeDefinition);
-	const after = indexDefinition(afterDefinition);
+	const aligned = alignDefinitionsForMatchMode(
+		beforeDefinition,
+		afterDefinition,
+		matchMode
+	);
+	const before = indexDefinition(aligned.before);
+	const after = indexDefinition(aligned.after);
 	const componentDiff = diffComponents(before, after);
 	const overlay = buildGraphOverlay(before, after, componentDiff.components);
 
@@ -68,5 +102,82 @@ export function diffGrasshopper(
 		...componentDiff,
 		...overlay,
 		counts: countStatuses(componentDiff.components),
+		matchMode,
 	};
+}
+
+/**
+ * Resolve a comparison using the preferred match mode. When preferring
+ * instance IDs, automatically fall back to type GUID matching if instance
+ * overlap is too low — before rejecting the comparison as unrelated.
+ */
+export function resolveDiffComparison(
+	beforeDefinition: ParsedGrasshopper,
+	afterDefinition: ParsedGrasshopper,
+	preferredMode: DiffMatchMode = "instance"
+): DiffComparisonResolution {
+	const preferredOverlap = assessDefinitionOverlap(
+		beforeDefinition,
+		afterDefinition,
+		preferredMode
+	);
+	if (preferredOverlap.isComparable) {
+		return {
+			overlap: preferredOverlap,
+			matchMode: preferredMode,
+			fellBackToType: false,
+			result: diffGrasshopper(
+				beforeDefinition,
+				afterDefinition,
+				preferredMode
+			),
+		};
+	}
+
+	if (preferredMode === "instance") {
+		const typeOverlap = assessDefinitionOverlap(
+			beforeDefinition,
+			afterDefinition,
+			"type"
+		);
+		if (typeOverlap.isComparable) {
+			return {
+				overlap: typeOverlap,
+				matchMode: "type",
+				fellBackToType: true,
+				result: diffGrasshopper(beforeDefinition, afterDefinition, "type"),
+			};
+		}
+
+		return {
+			overlap: preferredOverlap,
+			matchMode: preferredMode,
+			fellBackToType: false,
+			result: null,
+			failedTypeOverlap: typeOverlap,
+		};
+	}
+
+	return {
+		overlap: preferredOverlap,
+		matchMode: preferredMode,
+		fellBackToType: false,
+		result: null,
+	};
+}
+
+export function formatOverlapRejection(
+	overlap: DefinitionOverlap,
+	failedTypeOverlap?: DefinitionOverlap
+): string {
+	const modeLabel =
+		overlap.matchMode === "type" ? "type GUID" : "instance ID";
+	const base = `Only ${Math.round(overlap.ratio * 100)}% component overlap (${overlap.matchedCount} of ${overlap.smallerCount} matched by ${modeLabel}). Ducker requires at least 25% overlap${overlap.smallerCount > 5 ? " and 3 matched components" : ""}.`;
+	if (failedTypeOverlap) {
+		return `${base} Type GUID matching also fell short (${Math.round(failedTypeOverlap.ratio * 100)}% overlap, ${failedTypeOverlap.matchedCount} of ${failedTypeOverlap.smallerCount}).`;
+	}
+	if (overlap.matchMode === "instance") {
+		return `${base} Try matching by type GUID if components were newly placed.`;
+	}
+	return base;
 }

--- a/src/app/duckerweb/gh-diff.ts
+++ b/src/app/duckerweb/gh-diff.ts
@@ -95,7 +95,11 @@ export function diffGrasshopper(
 	);
 	const before = indexDefinition(aligned.before);
 	const after = indexDefinition(aligned.after);
-	const componentDiff = diffComponents(before, after);
+	const componentDiff = diffComponents(
+		before,
+		after,
+		aligned.replacedInstanceKeys
+	);
 	const overlay = buildGraphOverlay(before, after, componentDiff.components);
 
 	return {

--- a/src/app/duckerweb/hooks/use-duckerweb-state.ts
+++ b/src/app/duckerweb/hooks/use-duckerweb-state.ts
@@ -99,6 +99,10 @@ export function useDuckerwebState(): DuckerwebState & {
 	const [diffNotice, setDiffNotice] = useState("");
 	const activeRequest = useRef(0);
 	const activeComparisonRequest = useRef(0);
+	// Clipboard and file imports resolve asynchronously, so the mode has to be
+	// read when the diff runs — not when the import callback was created — or a
+	// toggle made mid-read would be ignored by the diff it is meant to control.
+	const matchModeRef = useRef<DiffMatchMode>("instance");
 	const applyComparisonResult = useCallback(
 		(
 			before: ParsedGrasshopper,
@@ -150,6 +154,7 @@ export function useDuckerwebState(): DuckerwebState & {
 		setComparisonFileName("");
 		setComparisonRejected(false);
 		setMatchByTypeGuidState(false);
+		matchModeRef.current = "instance";
 		setDiffNotice("");
 	}, []);
 
@@ -206,11 +211,11 @@ export function useDuckerwebState(): DuckerwebState & {
 			applyComparisonResult(
 				parsedData,
 				result.parsedData,
-				matchByTypeGuid ? "type" : "instance"
+				matchModeRef.current
 			);
 			setViewMode("diff");
 		},
-		[applyComparisonResult, matchByTypeGuid, parsedData]
+		[applyComparisonResult, parsedData]
 	);
 	const applyPastedXml = useCallback(
 		(text: string, requestId: number) => {
@@ -348,6 +353,7 @@ export function useDuckerwebState(): DuckerwebState & {
 	const setMatchByTypeGuid = useCallback(
 		(enabled: boolean) => {
 			setMatchByTypeGuidState(enabled);
+			matchModeRef.current = enabled ? "type" : "instance";
 			if (!parsedData || !comparisonData) {
 				setDiffNotice("");
 				return;

--- a/src/app/duckerweb/hooks/use-duckerweb-state.ts
+++ b/src/app/duckerweb/hooks/use-duckerweb-state.ts
@@ -96,17 +96,9 @@ export function useDuckerwebState(): DuckerwebState & {
 	const [comparisonFileName, setComparisonFileName] = useState("");
 	const [comparisonRejected, setComparisonRejected] = useState(false);
 	const [matchByTypeGuid, setMatchByTypeGuidState] = useState(false);
-	const [diffFellBackToType, setDiffFellBackToType] = useState(false);
+	const [diffNotice, setDiffNotice] = useState("");
 	const activeRequest = useRef(0);
 	const activeComparisonRequest = useRef(0);
-	const matchByTypeGuidRef = useRef(matchByTypeGuid);
-	matchByTypeGuidRef.current = matchByTypeGuid;
-
-	const preferredMatchMode = useCallback(
-		(): DiffMatchMode => (matchByTypeGuidRef.current ? "type" : "instance"),
-		[]
-	);
-
 	const applyComparisonResult = useCallback(
 		(
 			before: ParsedGrasshopper,
@@ -118,7 +110,7 @@ export function useDuckerwebState(): DuckerwebState & {
 				setComparisonRejected(true);
 				setComparisonData(after);
 				setDiffResult(null);
-				setDiffFellBackToType(false);
+				setDiffNotice("");
 				setDiffError(
 					formatOverlapRejection(
 						resolution.overlap,
@@ -131,12 +123,12 @@ export function useDuckerwebState(): DuckerwebState & {
 			setComparisonData(after);
 			setComparisonRejected(false);
 			setDiffResult(resolution.result);
-			setDiffFellBackToType(resolution.fellBackToType);
-			setDiffError(
+			setDiffNotice(
 				resolution.fellBackToType
 					? "Instance IDs did not overlap enough, so Ducker matched components by type GUID instead."
 					: ""
 			);
+			setDiffError("");
 			return true;
 		},
 		[]
@@ -158,7 +150,7 @@ export function useDuckerwebState(): DuckerwebState & {
 		setComparisonFileName("");
 		setComparisonRejected(false);
 		setMatchByTypeGuidState(false);
-		setDiffFellBackToType(false);
+		setDiffNotice("");
 	}, []);
 
 	/**
@@ -194,7 +186,7 @@ export function useDuckerwebState(): DuckerwebState & {
 			setFileName(name ?? "Clipboard GhXml");
 			setComparisonFileName("");
 			setComparisonRejected(false);
-			setDiffFellBackToType(false);
+			setDiffNotice("");
 		},
 		[]
 	);
@@ -205,8 +197,8 @@ export function useDuckerwebState(): DuckerwebState & {
 			const result = prepareDuckerwebImport(xml, source);
 
 			if (!result.ok) {
+				// Leave any notice in place: it still describes the diff on screen.
 				setComparisonRejected(false);
-				setDiffFellBackToType(false);
 				setDiffError(result.error);
 				return;
 			}
@@ -214,11 +206,11 @@ export function useDuckerwebState(): DuckerwebState & {
 			applyComparisonResult(
 				parsedData,
 				result.parsedData,
-				preferredMatchMode()
+				matchByTypeGuid ? "type" : "instance"
 			);
 			setViewMode("diff");
 		},
-		[applyComparisonResult, parsedData, preferredMatchMode]
+		[applyComparisonResult, matchByTypeGuid, parsedData]
 	);
 	const applyPastedXml = useCallback(
 		(text: string, requestId: number) => {
@@ -350,15 +342,14 @@ export function useDuckerwebState(): DuckerwebState & {
 		setDiffError("");
 		setComparisonFileName("");
 		setComparisonRejected(false);
-		setDiffFellBackToType(false);
+		setDiffNotice("");
 	}, []);
 
 	const setMatchByTypeGuid = useCallback(
 		(enabled: boolean) => {
 			setMatchByTypeGuidState(enabled);
-			matchByTypeGuidRef.current = enabled;
 			if (!parsedData || !comparisonData) {
-				setDiffFellBackToType(false);
+				setDiffNotice("");
 				return;
 			}
 			applyComparisonResult(
@@ -386,7 +377,7 @@ export function useDuckerwebState(): DuckerwebState & {
 		comparisonFileName,
 		comparisonRejected,
 		matchByTypeGuid,
-		diffFellBackToType,
+		diffNotice,
 		handlePasteFromClipboard,
 		handlePastedXml,
 		handleFileSelected,

--- a/src/app/duckerweb/hooks/use-duckerweb-state.ts
+++ b/src/app/duckerweb/hooks/use-duckerweb-state.ts
@@ -4,7 +4,11 @@ import type { ParsedGrasshopper } from "parser/src/types";
 import { validateGhXml } from "../../utils/gh-xml";
 import { GhFileError, ghFileToGhXml } from "../../utils/gh-file";
 import { generateFlowData } from "../gh-flow-generator";
-import { assessDefinitionOverlap, diffGrasshopper } from "../gh-diff";
+import {
+	formatOverlapRejection,
+	resolveDiffComparison,
+	type DiffMatchMode,
+} from "../gh-diff";
 import type {
 	DuckerwebImportResult,
 	DuckerwebState,
@@ -74,6 +78,7 @@ export function useDuckerwebState(): DuckerwebState & {
 	handleClearComparison: () => void;
 	handleClear: () => void;
 	setViewMode: React.Dispatch<React.SetStateAction<ViewMode>>;
+	setMatchByTypeGuid: (enabled: boolean) => void;
 } {
 	const [xmlData, setXmlData] = useState<string | undefined>();
 	const [isValidXml, setIsValidXml] = useState(false);
@@ -90,8 +95,52 @@ export function useDuckerwebState(): DuckerwebState & {
 	const [fileName, setFileName] = useState("");
 	const [comparisonFileName, setComparisonFileName] = useState("");
 	const [comparisonRejected, setComparisonRejected] = useState(false);
+	const [matchByTypeGuid, setMatchByTypeGuidState] = useState(false);
+	const [diffFellBackToType, setDiffFellBackToType] = useState(false);
 	const activeRequest = useRef(0);
 	const activeComparisonRequest = useRef(0);
+	const matchByTypeGuidRef = useRef(matchByTypeGuid);
+	matchByTypeGuidRef.current = matchByTypeGuid;
+
+	const preferredMatchMode = useCallback(
+		(): DiffMatchMode => (matchByTypeGuidRef.current ? "type" : "instance"),
+		[]
+	);
+
+	const applyComparisonResult = useCallback(
+		(
+			before: ParsedGrasshopper,
+			after: ParsedGrasshopper,
+			mode: DiffMatchMode
+		) => {
+			const resolution = resolveDiffComparison(before, after, mode);
+			if (!resolution.result) {
+				setComparisonRejected(true);
+				setComparisonData(after);
+				setDiffResult(null);
+				setDiffFellBackToType(false);
+				setDiffError(
+					formatOverlapRejection(
+						resolution.overlap,
+						resolution.failedTypeOverlap
+					)
+				);
+				return false;
+			}
+
+			setComparisonData(after);
+			setComparisonRejected(false);
+			setDiffResult(resolution.result);
+			setDiffFellBackToType(resolution.fellBackToType);
+			setDiffError(
+				resolution.fellBackToType
+					? "Instance IDs did not overlap enough, so Ducker matched components by type GUID instead."
+					: ""
+			);
+			return true;
+		},
+		[]
+	);
 
 	const resetFlowState = useCallback(() => {
 		setXmlData(undefined);
@@ -108,6 +157,8 @@ export function useDuckerwebState(): DuckerwebState & {
 		setFileName("");
 		setComparisonFileName("");
 		setComparisonRejected(false);
+		setMatchByTypeGuidState(false);
+		setDiffFellBackToType(false);
 	}, []);
 
 	/**
@@ -143,6 +194,7 @@ export function useDuckerwebState(): DuckerwebState & {
 			setFileName(name ?? "Clipboard GhXml");
 			setComparisonFileName("");
 			setComparisonRejected(false);
+			setDiffFellBackToType(false);
 		},
 		[]
 	);
@@ -154,29 +206,19 @@ export function useDuckerwebState(): DuckerwebState & {
 
 			if (!result.ok) {
 				setComparisonRejected(false);
+				setDiffFellBackToType(false);
 				setDiffError(result.error);
 				return;
 			}
-			const overlap = assessDefinitionOverlap(parsedData, result.parsedData);
 			setComparisonFileName(name ?? "Clipboard GhXml");
-			if (!overlap.isComparable) {
-				setComparisonRejected(true);
-				setComparisonData(null);
-				setDiffResult(null);
-				setDiffError(
-					`Only ${Math.round(overlap.ratio * 100)}% component overlap (${overlap.matchedCount} of ${overlap.smallerCount} matched). Ducker requires at least 25% overlap${overlap.smallerCount > 5 ? " and 3 matched components" : ""}.`
-				);
-				setViewMode("diff");
-				return;
-			}
-
-			setComparisonData(result.parsedData);
-			setComparisonRejected(false);
-			setDiffResult(diffGrasshopper(parsedData, result.parsedData));
-			setDiffError("");
+			applyComparisonResult(
+				parsedData,
+				result.parsedData,
+				preferredMatchMode()
+			);
 			setViewMode("diff");
 		},
-		[parsedData]
+		[applyComparisonResult, parsedData, preferredMatchMode]
 	);
 	const applyPastedXml = useCallback(
 		(text: string, requestId: number) => {
@@ -308,7 +350,25 @@ export function useDuckerwebState(): DuckerwebState & {
 		setDiffError("");
 		setComparisonFileName("");
 		setComparisonRejected(false);
+		setDiffFellBackToType(false);
 	}, []);
+
+	const setMatchByTypeGuid = useCallback(
+		(enabled: boolean) => {
+			setMatchByTypeGuidState(enabled);
+			matchByTypeGuidRef.current = enabled;
+			if (!parsedData || !comparisonData) {
+				setDiffFellBackToType(false);
+				return;
+			}
+			applyComparisonResult(
+				parsedData,
+				comparisonData,
+				enabled ? "type" : "instance"
+			);
+		},
+		[applyComparisonResult, comparisonData, parsedData]
+	);
 
 	return {
 		xmlData,
@@ -325,6 +385,8 @@ export function useDuckerwebState(): DuckerwebState & {
 		fileName,
 		comparisonFileName,
 		comparisonRejected,
+		matchByTypeGuid,
+		diffFellBackToType,
 		handlePasteFromClipboard,
 		handlePastedXml,
 		handleFileSelected,
@@ -334,5 +396,6 @@ export function useDuckerwebState(): DuckerwebState & {
 		handleClearComparison,
 		handleClear,
 		setViewMode,
+		setMatchByTypeGuid,
 	};
 }

--- a/src/app/duckerweb/lib/gh-diff/component-diff.ts
+++ b/src/app/duckerweb/lib/gh-diff/component-diff.ts
@@ -169,7 +169,8 @@ function componentDetailChanges(before: Component, after: Component): string[] {
 	return COMPONENT_DETAIL_KEYS.flatMap((key) => {
 		if (before[key] === after[key]) return [];
 		const label = COMPONENT_DETAIL_LABELS[key];
-		if (key === "description") return descriptionChange(before[key], after[key]);
+		if (key === "description")
+			return descriptionChange(before[key], after[key]);
 		if (!before[key]) return [`${label} added`];
 		if (!after[key]) return [`${label} removed`];
 		if (key === "nickName" || key === "type" || key === "library") {

--- a/src/app/duckerweb/lib/gh-diff/component-diff.ts
+++ b/src/app/duckerweb/lib/gh-diff/component-diff.ts
@@ -33,8 +33,19 @@ const COMPONENT_DETAIL_KEYS = [
 	"library",
 	"description",
 ] as const;
+const COMPONENT_DETAIL_LABELS: Record<
+	(typeof COMPONENT_DETAIL_KEYS)[number],
+	string
+> = {
+	type: "Type",
+	typeGuid: "Type GUID",
+	nickName: "Nickname",
+	library: "Library",
+	description: "Description",
+};
 const EXPRESSION_KEYS = ["expression", "internalExpression"] as const;
 const STATE_KEYS = ["hidden", "locked", "frozen"] as const;
+export const NEWLY_PLACED_CHANGE = "Same component, newly placed";
 
 const PORT_OPTION_LABELS: Record<
 	Exclude<keyof PortOptions, "mapping" | "expression">,
@@ -154,6 +165,20 @@ function componentFieldsChanged(
 	return keys.some((key) => before[key] !== after[key]);
 }
 
+function componentDetailChanges(before: Component, after: Component): string[] {
+	return COMPONENT_DETAIL_KEYS.flatMap((key) => {
+		if (before[key] === after[key]) return [];
+		const label = COMPONENT_DETAIL_LABELS[key];
+		if (key === "description") return descriptionChange(before[key], after[key]);
+		if (!before[key]) return [`${label} added`];
+		if (!after[key]) return [`${label} removed`];
+		if (key === "nickName" || key === "type" || key === "library") {
+			return [`${label} ${before[key]} → ${after[key]}`];
+		}
+		return [`${label} changed`];
+	});
+}
+
 function runtimeStateChanged(before: Component, after: Component): boolean {
 	return STATE_KEYS.some((key) => before.state?.[key] !== after.state?.[key]);
 }
@@ -178,13 +203,8 @@ function runtimeStateChanges(before: Component, after: Component): string[] {
  */
 const CHANGE_RULES: readonly ChangeRule[] = [
 	{
-		label: "Component details",
-		changed: (before, after) =>
-			componentFieldsChanged(
-				before.component,
-				after.component,
-				COMPONENT_DETAIL_KEYS
-			),
+		describe: (before, after) =>
+			componentDetailChanges(before.component, after.component),
 	},
 	{
 		describe: (before, after) =>
@@ -274,7 +294,8 @@ const STATUS_ORDER: Record<GHDiffStatus, number> = {
 
 export function diffComponents(
 	before: DefinitionIndex,
-	after: DefinitionIndex
+	after: DefinitionIndex,
+	replacedInstanceKeys: ReadonlySet<string> = new Set()
 ): { components: GHComponentDiff[]; layoutMoves: number } {
 	const keys = new Set([
 		...before.componentsByKey.keys(),
@@ -301,6 +322,9 @@ export function diffComponents(
 			{ component: oldComponent, definition: before },
 			{ component: newComponent, definition: after }
 		);
+		if (replacedInstanceKeys.has(key)) {
+			changes.unshift(NEWLY_PLACED_CHANGE);
+		}
 		const layoutMoved = hasMoved(oldComponent, newComponent);
 		if (layoutMoved) layoutMoves += 1;
 		components.push({

--- a/src/app/duckerweb/lib/gh-diff/match-align.ts
+++ b/src/app/duckerweb/lib/gh-diff/match-align.ts
@@ -27,7 +27,12 @@ function componentPosition(
 	return point ? { x: point.x, y: point.y } : null;
 }
 
+// An identical instance GUID is proof of identity, so it must outrank every
+// heuristic below: a component the user never replaced always pairs with itself.
+const INSTANCE_MATCH_SCORE = 1_000_000;
+
 function pairScore(before: Component, after: Component): number {
+	if (componentKey(before) === componentKey(after)) return INSTANCE_MATCH_SCORE;
 	let score = 1;
 	if (before.nickName === after.nickName) score += 1000;
 	const beforePos = componentPosition(before);
@@ -87,7 +92,6 @@ function remapPorts(
 	afterPorts: Record<string, DiffablePort>,
 	portRemap: Map<string, string>
 ) {
-	const beforeList = Object.values(beforePorts);
 	const afterList = Object.values(afterPorts).map((port) => ({
 		port,
 		originalGuid: port.instanceGuid,
@@ -104,25 +108,21 @@ function remapPorts(
 		entry.port.instanceGuid = beforePort.instanceGuid;
 	};
 
-	for (const beforePort of beforeList) {
-		claim(
-			beforePort,
-			afterList.find(
-				(entry) => !entry.used && entry.port.nick === beforePort.nick
-			)
+	const unclaimedBefore: DiffablePort[] = [];
+	for (const beforePort of Object.values(beforePorts)) {
+		const byNick = afterList.find(
+			(entry) => !entry.used && entry.port.nick === beforePort.nick
 		);
+		if (byNick) claim(beforePort, byNick);
+		else unclaimedBefore.push(beforePort);
 	}
 
-	const unmatchedBefore = beforeList.filter(
-		(beforePort) =>
-			!afterList.some(
-				(entry) => entry.port.instanceGuid === beforePort.instanceGuid
-			)
+	// Renamed ports have no nickname anchor left, so pair the leftovers in
+	// declaration order rather than reporting them as removed plus added.
+	const unclaimedAfter = afterList.filter((entry) => !entry.used);
+	unclaimedBefore.forEach((beforePort, index) =>
+		claim(beforePort, unclaimedAfter[index])
 	);
-	const unmatchedAfter = afterList.filter((entry) => !entry.used);
-	for (let index = 0; index < unmatchedBefore.length; index += 1) {
-		claim(unmatchedBefore[index], unmatchedAfter[index]);
-	}
 }
 
 /**
@@ -167,10 +167,24 @@ export function alignDefinitionsForMatchMode(
 	const instanceRemap = new Map<string, string>();
 	const portRemap = new Map<string, string>();
 	const replacedInstanceKeys = new Set<string>();
+	// Keys still owned by an after-side component that stayed unpaired. Renaming
+	// a pair onto one of those would produce two components with the same key,
+	// and the key-indexed diff would silently drop one of them.
+	const pairedAfterKeys = new Set(
+		pairs.map((pair) => componentKey(pair.after))
+	);
+	const unpairedAfterKeys = new Set(
+		Object.values(after.components)
+			.map(componentKey)
+			.filter((key) => !pairedAfterKeys.has(key))
+	);
+	let matchedCount = 0;
 
 	for (const pair of pairs) {
 		const beforeKey = componentKey(pair.before);
 		const afterKey = componentKey(pair.after);
+		if (beforeKey !== afterKey && unpairedAfterKeys.has(beforeKey)) continue;
+		matchedCount += 1;
 		instanceRemap.set(afterKey, beforeKey);
 		if (beforeKey !== afterKey) replacedInstanceKeys.add(beforeKey);
 		pair.after.instanceGuid = beforeKey;
@@ -193,5 +207,5 @@ export function alignDefinitionsForMatchMode(
 		if (remappedTarget) wire.targetPortGuid = remappedTarget;
 	}
 
-	return { before, after, matchedCount: pairs.length, replacedInstanceKeys };
+	return { before, after, matchedCount, replacedInstanceKeys };
 }

--- a/src/app/duckerweb/lib/gh-diff/match-align.ts
+++ b/src/app/duckerweb/lib/gh-diff/match-align.ts
@@ -1,0 +1,190 @@
+import type {
+	Component,
+	InputPort,
+	OutputPort,
+	ParsedGrasshopper,
+} from "parser/src/types";
+import { componentKey } from "./definition-index";
+
+export type DiffMatchMode = "instance" | "type";
+
+type DiffablePort = InputPort | OutputPort;
+
+type ComponentPair = {
+	before: Component;
+	after: Component;
+	score: number;
+};
+
+function typeIdentity(component: Component): string {
+	return component.typeGuid || component.type || component.id;
+}
+
+function componentPosition(
+	component: Component
+): { x: number; y: number } | null {
+	const point = component.visuals?.pivot ?? component.visuals?.bounds;
+	return point ? { x: point.x, y: point.y } : null;
+}
+
+function pairScore(before: Component, after: Component): number {
+	let score = 1;
+	if (before.nickName === after.nickName) score += 1000;
+	const beforePos = componentPosition(before);
+	const afterPos = componentPosition(after);
+	if (beforePos && afterPos) {
+		const distance = Math.hypot(
+			beforePos.x - afterPos.x,
+			beforePos.y - afterPos.y
+		);
+		score += Math.max(0, 500 - distance);
+	}
+	return score;
+}
+
+/**
+ * Greedy 1:1 pairing for components that share a type GUID. Prefers matching
+ * nicknames and nearby canvas positions when several instances exist.
+ */
+export function pairComponentsByType(
+	beforeComponents: Component[],
+	afterComponents: Component[]
+): Array<{ before: Component; after: Component }> {
+	const candidates: ComponentPair[] = [];
+	for (const before of beforeComponents) {
+		for (const after of afterComponents) {
+			if (typeIdentity(before) !== typeIdentity(after)) continue;
+			candidates.push({
+				before,
+				after,
+				score: pairScore(before, after),
+			});
+		}
+	}
+
+	candidates.sort(
+		(a, b) => b.score - a.score || a.before.id.localeCompare(b.before.id)
+	);
+
+	const usedBefore = new Set<string>();
+	const usedAfter = new Set<string>();
+	const pairs: Array<{ before: Component; after: Component }> = [];
+
+	for (const candidate of candidates) {
+		const beforeKey = componentKey(candidate.before);
+		const afterKey = componentKey(candidate.after);
+		if (usedBefore.has(beforeKey) || usedAfter.has(afterKey)) continue;
+		usedBefore.add(beforeKey);
+		usedAfter.add(afterKey);
+		pairs.push({ before: candidate.before, after: candidate.after });
+	}
+
+	return pairs;
+}
+
+function remapPorts(
+	beforePorts: Record<string, DiffablePort>,
+	afterPorts: Record<string, DiffablePort>,
+	portRemap: Map<string, string>
+) {
+	const beforeList = Object.values(beforePorts);
+	const afterList = Object.values(afterPorts).map((port) => ({
+		port,
+		originalGuid: port.instanceGuid,
+		used: false,
+	}));
+
+	const claim = (
+		beforePort: DiffablePort,
+		entry: (typeof afterList)[number] | undefined
+	) => {
+		if (!entry) return;
+		entry.used = true;
+		portRemap.set(entry.originalGuid, beforePort.instanceGuid);
+		entry.port.instanceGuid = beforePort.instanceGuid;
+	};
+
+	for (const beforePort of beforeList) {
+		claim(
+			beforePort,
+			afterList.find(
+				(entry) => !entry.used && entry.port.nick === beforePort.nick
+			)
+		);
+	}
+
+	const unmatchedBefore = beforeList.filter(
+		(beforePort) =>
+			!afterList.some(
+				(entry) => entry.port.instanceGuid === beforePort.instanceGuid
+			)
+	);
+	const unmatchedAfter = afterList.filter((entry) => !entry.used);
+	for (let index = 0; index < unmatchedBefore.length; index += 1) {
+		claim(unmatchedBefore[index], unmatchedAfter[index]);
+	}
+}
+
+/**
+ * Align two definitions so the shared diff pipeline can key by instance GUID.
+ * In `type` mode, after-side instance/port GUIDs are rewritten onto their
+ * type-paired before counterparts (and wires are remapped accordingly).
+ */
+export function alignDefinitionsForMatchMode(
+	beforeDefinition: ParsedGrasshopper,
+	afterDefinition: ParsedGrasshopper,
+	mode: DiffMatchMode
+): {
+	before: ParsedGrasshopper;
+	after: ParsedGrasshopper;
+	matchedCount: number;
+} {
+	if (mode === "instance") {
+		const beforeKeys = new Set(
+			Object.values(beforeDefinition.components).map(componentKey)
+		);
+		const matchedCount = Object.values(afterDefinition.components).filter(
+			(component) => beforeKeys.has(componentKey(component))
+		).length;
+		return {
+			before: beforeDefinition,
+			after: afterDefinition,
+			matchedCount,
+		};
+	}
+
+	const before = beforeDefinition;
+	const after = structuredClone(afterDefinition);
+	const pairs = pairComponentsByType(
+		Object.values(before.components),
+		Object.values(after.components)
+	);
+	const instanceRemap = new Map<string, string>();
+	const portRemap = new Map<string, string>();
+
+	for (const pair of pairs) {
+		const beforeKey = componentKey(pair.before);
+		const afterKey = componentKey(pair.after);
+		instanceRemap.set(afterKey, beforeKey);
+		pair.after.instanceGuid = beforeKey;
+		remapPorts(pair.before.inputs, pair.after.inputs, portRemap);
+		remapPorts(pair.before.outputs, pair.after.outputs, portRemap);
+	}
+
+	for (const wire of after.wires) {
+		// Despite the name, sourceComponentGuid is usually an output port GUID.
+		if (wire.sourceComponentGuid) {
+			const remappedSource =
+				portRemap.get(wire.sourceComponentGuid) ??
+				instanceRemap.get(wire.sourceComponentGuid);
+			if (remappedSource) wire.sourceComponentGuid = remappedSource;
+		}
+
+		const remappedTarget = wire.targetPortGuid
+			? portRemap.get(wire.targetPortGuid)
+			: undefined;
+		if (remappedTarget) wire.targetPortGuid = remappedTarget;
+	}
+
+	return { before, after, matchedCount: pairs.length };
+}

--- a/src/app/duckerweb/lib/gh-diff/match-align.ts
+++ b/src/app/duckerweb/lib/gh-diff/match-align.ts
@@ -129,6 +129,9 @@ function remapPorts(
  * Align two definitions so the shared diff pipeline can key by instance GUID.
  * In `type` mode, after-side instance/port GUIDs are rewritten onto their
  * type-paired before counterparts (and wires are remapped accordingly).
+ *
+ * `replacedInstanceKeys` lists shared keys whose after-side instance GUID
+ * originally differed — i.e. same type, newly placed component.
  */
 export function alignDefinitionsForMatchMode(
 	beforeDefinition: ParsedGrasshopper,
@@ -138,6 +141,7 @@ export function alignDefinitionsForMatchMode(
 	before: ParsedGrasshopper;
 	after: ParsedGrasshopper;
 	matchedCount: number;
+	replacedInstanceKeys: Set<string>;
 } {
 	if (mode === "instance") {
 		const beforeKeys = new Set(
@@ -150,6 +154,7 @@ export function alignDefinitionsForMatchMode(
 			before: beforeDefinition,
 			after: afterDefinition,
 			matchedCount,
+			replacedInstanceKeys: new Set(),
 		};
 	}
 
@@ -161,11 +166,13 @@ export function alignDefinitionsForMatchMode(
 	);
 	const instanceRemap = new Map<string, string>();
 	const portRemap = new Map<string, string>();
+	const replacedInstanceKeys = new Set<string>();
 
 	for (const pair of pairs) {
 		const beforeKey = componentKey(pair.before);
 		const afterKey = componentKey(pair.after);
 		instanceRemap.set(afterKey, beforeKey);
+		if (beforeKey !== afterKey) replacedInstanceKeys.add(beforeKey);
 		pair.after.instanceGuid = beforeKey;
 		remapPorts(pair.before.inputs, pair.after.inputs, portRemap);
 		remapPorts(pair.before.outputs, pair.after.outputs, portRemap);
@@ -186,5 +193,5 @@ export function alignDefinitionsForMatchMode(
 		if (remappedTarget) wire.targetPortGuid = remappedTarget;
 	}
 
-	return { before, after, matchedCount: pairs.length };
+	return { before, after, matchedCount: pairs.length, replacedInstanceKeys };
 }

--- a/src/app/duckerweb/lib/gh-diff/match-align.ts
+++ b/src/app/duckerweb/lib/gh-diff/match-align.ts
@@ -95,34 +95,43 @@ function remapPorts(
 	const afterList = Object.values(afterPorts).map((port) => ({
 		port,
 		originalGuid: port.instanceGuid,
-		used: false,
+		claimedBy: undefined as DiffablePort | undefined,
 	}));
-
-	const claim = (
-		beforePort: DiffablePort,
-		entry: (typeof afterList)[number] | undefined
-	) => {
-		if (!entry) return;
-		entry.used = true;
-		portRemap.set(entry.originalGuid, beforePort.instanceGuid);
-		entry.port.instanceGuid = beforePort.instanceGuid;
-	};
 
 	const unclaimedBefore: DiffablePort[] = [];
 	for (const beforePort of Object.values(beforePorts)) {
 		const byNick = afterList.find(
-			(entry) => !entry.used && entry.port.nick === beforePort.nick
+			(entry) => !entry.claimedBy && entry.port.nick === beforePort.nick
 		);
-		if (byNick) claim(beforePort, byNick);
+		if (byNick) byNick.claimedBy = beforePort;
 		else unclaimedBefore.push(beforePort);
 	}
 
 	// Renamed ports have no nickname anchor left, so pair the leftovers in
 	// declaration order rather than reporting them as removed plus added.
-	const unclaimedAfter = afterList.filter((entry) => !entry.used);
-	unclaimedBefore.forEach((beforePort, index) =>
-		claim(beforePort, unclaimedAfter[index])
+	const unclaimedAfter = afterList.filter((entry) => !entry.claimedBy);
+	unclaimedBefore.forEach((beforePort, index) => {
+		const entry = unclaimedAfter[index];
+		if (entry) entry.claimedBy = beforePort;
+	});
+
+	// Ports left over on the after side keep their own GUID, so renaming a
+	// claimed port onto one of those would produce two ports sharing a GUID and
+	// the GUID-indexed port diff would silently drop one of them.
+	const unclaimedGuids = new Set(
+		afterList
+			.filter((entry) => !entry.claimedBy)
+			.map((entry) => entry.originalGuid)
 	);
+
+	for (const entry of afterList) {
+		const beforePort = entry.claimedBy;
+		if (!beforePort) continue;
+		const target = beforePort.instanceGuid;
+		if (target !== entry.originalGuid && unclaimedGuids.has(target)) continue;
+		portRemap.set(entry.originalGuid, target);
+		entry.port.instanceGuid = target;
+	}
 }
 
 /**

--- a/src/app/duckerweb/lib/gh-diff/match-align.ts
+++ b/src/app/duckerweb/lib/gh-diff/match-align.ts
@@ -55,10 +55,20 @@ export function pairComponentsByType(
 	beforeComponents: Component[],
 	afterComponents: Component[]
 ): Array<{ before: Component; after: Component }> {
+	// Bucketing keeps the candidate scan quadratic only within a single type
+	// rather than across the whole definition, which matters on canvases that
+	// carry hundreds of components of many different types.
+	const afterByType = new Map<string, Component[]>();
+	for (const after of afterComponents) {
+		const identity = typeIdentity(after);
+		const bucket = afterByType.get(identity);
+		if (bucket) bucket.push(after);
+		else afterByType.set(identity, [after]);
+	}
+
 	const candidates: ComponentPair[] = [];
 	for (const before of beforeComponents) {
-		for (const after of afterComponents) {
-			if (typeIdentity(before) !== typeIdentity(after)) continue;
+		for (const after of afterByType.get(typeIdentity(before)) ?? []) {
 			candidates.push({
 				before,
 				after,
@@ -156,9 +166,13 @@ export function alignDefinitionsForMatchMode(
 		const beforeKeys = new Set(
 			Object.values(beforeDefinition.components).map(componentKey)
 		);
-		const matchedCount = Object.values(afterDefinition.components).filter(
-			(component) => beforeKeys.has(componentKey(component))
-		).length;
+		// Count distinct keys: the diff itself is keyed, so two after-side
+		// components sharing a key must not inflate the overlap ratio past 1.
+		const matchedCount = new Set(
+			Object.values(afterDefinition.components)
+				.map(componentKey)
+				.filter((key) => beforeKeys.has(key))
+		).size;
 		return {
 			before: beforeDefinition,
 			after: afterDefinition,

--- a/src/app/duckerweb/page.tsx
+++ b/src/app/duckerweb/page.tsx
@@ -45,6 +45,8 @@ export default function DuckerWebPage() {
 		fileName,
 		comparisonFileName,
 		comparisonRejected,
+		matchByTypeGuid,
+		diffFellBackToType,
 		handlePasteFromClipboard,
 		handlePastedXml,
 		handleFileSelected,
@@ -54,6 +56,7 @@ export default function DuckerWebPage() {
 		handleClearComparison,
 		handleClear,
 		setViewMode,
+		setMatchByTypeGuid,
 	} = useDuckerwebState();
 
 	const { handleCopyAll, isCopied } = useMarkdownExport(parsedData);
@@ -85,6 +88,9 @@ export default function DuckerWebPage() {
 				originalFileName={fileName}
 				comparisonFileName={comparisonFileName}
 				comparisonRejected={comparisonRejected}
+				matchByTypeGuid={matchByTypeGuid}
+				diffFellBackToType={diffFellBackToType}
+				onMatchByTypeGuidChange={setMatchByTypeGuid}
 			/>
 		),
 		list: parsedData && <ComponentList parsedData={parsedData} />,

--- a/src/app/duckerweb/page.tsx
+++ b/src/app/duckerweb/page.tsx
@@ -46,7 +46,7 @@ export default function DuckerWebPage() {
 		comparisonFileName,
 		comparisonRejected,
 		matchByTypeGuid,
-		diffFellBackToType,
+		diffNotice,
 		handlePasteFromClipboard,
 		handlePastedXml,
 		handleFileSelected,
@@ -89,7 +89,7 @@ export default function DuckerWebPage() {
 				comparisonFileName={comparisonFileName}
 				comparisonRejected={comparisonRejected}
 				matchByTypeGuid={matchByTypeGuid}
-				diffFellBackToType={diffFellBackToType}
+				diffNotice={diffNotice}
 				onMatchByTypeGuidChange={setMatchByTypeGuid}
 			/>
 		),

--- a/src/app/duckerweb/types/type.ts
+++ b/src/app/duckerweb/types/type.ts
@@ -107,7 +107,7 @@ export type DuckerwebState = {
 	comparisonFileName: string;
 	comparisonRejected: boolean;
 	matchByTypeGuid: boolean;
-	diffFellBackToType: boolean;
+	diffNotice: string;
 };
 
 export type DuckerwebImportResult =

--- a/src/app/duckerweb/types/type.ts
+++ b/src/app/duckerweb/types/type.ts
@@ -69,6 +69,8 @@ export type ViewMode = "list" | "flow" | "diff" | "json";
 
 export type GHDiffStatus = "added" | "modified" | "removed" | "unchanged";
 
+export type GHDiffMatchMode = "instance" | "type";
+
 export type GHComponentDiff = {
 	key: string;
 	label: string;
@@ -86,6 +88,7 @@ export type GHDiffResult = {
 	removedWires: number;
 	nodes: GHNode[];
 	edges: Edge[];
+	matchMode: GHDiffMatchMode;
 };
 
 export type DuckerwebState = {
@@ -103,6 +106,8 @@ export type DuckerwebState = {
 	fileName: string;
 	comparisonFileName: string;
 	comparisonRejected: boolean;
+	matchByTypeGuid: boolean;
+	diffFellBackToType: boolean;
 };
 
 export type DuckerwebImportResult =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Diff view can optionally match components by **type GUID**, not only instance ID—useful when a component was newly placed but still does the same work.

- **Toggle:** “Match by type GUID” in the Diff view (empty, rejected, and active states).
- **Auto-fallback:** If instance-ID overlap is too low, matching retries by type GUID before rejecting the comparison.
- **Pairing:** Same-`typeGuid` components are paired 1:1 (nickname + canvas position), with ports/wires remapped so connections still compare.
- **Clearer change list:** Type-matched replacements show **Same component, newly placed**, plus specific field changes (e.g. `Nickname A → B`, `Value`) instead of a bare “Modified” / vague “Component details”.
- **UI label:** Shows `matched by instance ID`, `matched by type GUID`, or `matched by type GUID (auto)`.

## Test plan
- [ ] Load a definition, open Diff, paste a copy with rewritten instance GUIDs but same type GUIDs — expect auto-fallback and sidebar items like “Same component, newly placed”.
- [ ] Change a value on a type-matched component — expect “Same component, newly placed · Value”.
- [ ] Toggle **Match by type GUID** on/off for an existing comparison and confirm the mode label updates.
- [ ] Compare two unrelated definitions — expect rejection after both instance and type overlap fail.
- [ ] `pnpm exec vitest run src/app/duckerweb/gh-diff.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f98b5-7e4b-7053-91b0-b9afcf237285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f98b5-7e4b-7053-91b0-b9afcf237285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to match Grasshopper components by type GUID or instance GUID.
  * Displays the active matching mode in the diff view.
  * Shows notices when comparisons fall back to type-based matching.
  * Expanded component change details, including nickname, description, library, and type updates.
  * Flags newly placed components in comparison results.

* **Bug Fixes**
  * Improved matching accuracy for renamed, replaced, and newly placed components.
  * Prevented components, ports, or wires from being dropped during GUID collisions.
  * Added clearer overlap rejection messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->