### PR TITLE
fix(security): tighten tag charset/length and sortOrder validation

### DIFF
--- a/convex/ghCard.ts
+++ b/convex/ghCard.ts
@@ -5,7 +5,7 @@ import {
 	ShareLinkUidSchema,
 	StorageKeySchema,
 	UserTag,
-	SortOrder,
+	SortOrderZenum,
 } from "../src/types/types";
 import { generateSharableLinkUid } from "../src/utils/generage-shareable-link-uid";
 
@@ -145,7 +145,7 @@ export const getAll = query({
 		}
 
 		const tags = args.tags ?? [];
-		const sortOrder = args.sortOrder || "descLastEdited";
+		const sortOrder = SortOrderZenum.parse(args.sortOrder ?? "descLastEdited");
 
 		if (tags.length === 0 && sortOrder === "ascLastEdited") {
 			return await ctx.db
@@ -158,7 +158,7 @@ export const getAll = query({
 		}
 
 		let posts;
-		switch (sortOrder as SortOrder) {
+		switch (sortOrder) {
 			case "ascAZ":
 				posts = await ctx.db
 					.query("post")
@@ -219,15 +219,10 @@ export const getAll = query({
 					.collect();
 				break;
 
-			default:
-				posts = await ctx.db
-					.query("post")
-					.withIndex("by_user_name", (q) =>
-						q.eq("clerkUserId", identity.id as string)
-					)
-					.order("asc")
-					.collect();
-				break;
+			default: {
+				const _exhaustive: never = sortOrder;
+				throw new Error(`Unhandled sortOrder: ${_exhaustive}`);
+			}
 		}
 
 		if (tags.length === 0) return posts;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -9,7 +9,16 @@ export type GetSharedPost = FunctionReturnType<typeof api.ghCard.getSharedPost>;
 export const GhCardSchema = z.object({
 	name: z.string().min(3).max(30),
 	description: z.string().max(150),
-	tags: z.array(z.string()).max(20),
+	// Convex schema keeps v.array(v.string()); Zod enforces charset/length at mutation time.
+	tags: z
+		.array(
+			z
+				.string()
+				.min(1)
+				.max(20)
+				.regex(/^[\p{L}\p{N}]+$/u)
+		)
+		.max(20),
 });
 
 export type GhCard = z.infer<typeof GhCardSchema>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements **SECURITY_AUDIT PR 4** — findings #5 and #13.

- `GhCardSchema.tags`: each tag `.min(1).max(20).regex(/^[\p{L}\p{N}]+$/u)`, array max 20 (matches UI)
- `getAll` `sortOrder` validated with `SortOrderZenum.parse` (exhaustive switch, no cast)

## Test plan
- [ ] Add/update card with valid Unicode letter/number tags
- [ ] Direct mutation with oversized/special-char tags is rejected
- [ ] Sort order filters still work; invalid sortOrder errors cleanly

**Note:** Existing posts with non-conforming tags may fail updates until cleaned up.

Suggested merge after PR1–PR3 (or anytime; isolated).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2801cf5a-bc6d-4114-af7f-54b7d7dc5f87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2801cf5a-bc6d-4114-af7f-54b7d7dc5f87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

