### PR TITLE
fix(security): sanitize Shiki HTML and harden parser map keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"convex": "^1.42.1",
+		"dompurify": "^3.4.12",
 		"fast-xml-parser": "^5.9.3",
 		"fuse.js": "^7.4.2",
 		"lucide-react": "^0.536.0",

--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -53,13 +53,19 @@ function normalizeArray<T>(item: T | T[] | undefined): T[] {
 	return Array.isArray(item) ? item : [item];
 }
 
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function isSafeKey(key: string) {
+	return !DANGEROUS_KEYS.has(key);
+}
+
 function extractItems(chunk: XmlChunk): Record<string, unknown> {
-	const result: Record<string, unknown> = {};
+	const result = Object.create(null) as Record<string, unknown>;
 	const items = normalizeArray(chunk.items?.item);
 
 	for (const item of items) {
 		const name = item.name;
-		if (!name) continue;
+		if (!name || !isSafeKey(name)) continue;
 
 		const typeName = item.type_name;
 		const text = item["#text"];
@@ -68,6 +74,7 @@ function extractItems(chunk: XmlChunk): Record<string, unknown> {
 		if (text !== undefined) {
 			// Handle indexed items (e.g., ID_0, ID_1 for groups)
 			const key = index !== undefined ? `${name}_${index}` : name;
+			if (!isSafeKey(key)) continue;
 
 			// Try to parse as number or boolean
 			if (text === "true") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       convex:
         specifier: ^1.42.1
         version: 1.42.1(@clerk/clerk-react@5.61.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@clerk/react@6.7.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      dompurify:
+        specifier: ^3.4.12
+        version: 3.4.12
       fast-xml-parser:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2186,8 +2189,8 @@ packages:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   electron-to-chromium@1.5.384:
     resolution: {integrity: sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==}
@@ -5374,7 +5377,7 @@ snapshots:
 
   diff@8.0.4: {}
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -6052,7 +6055,7 @@ snapshots:
       '@posthog/core': 1.39.4
       '@posthog/types': 1.392.0
       core-js: 3.49.0
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       fflate: 0.4.8
       preact: 10.29.3
       query-selector-shadow-dom: 1.0.1

--- a/src/app/duckerweb/components/GHJsonView.tsx
+++ b/src/app/duckerweb/components/GHJsonView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import DOMPurify from "dompurify";
 import type { ParsedGrasshopper } from "parser/src/types";
 
 interface GHJsonViewProps {
@@ -22,7 +23,7 @@ export function GHJsonView({ data }: GHJsonViewProps) {
 					lang: "json",
 					theme: "catppuccin-mocha",
 				});
-				setHtml(rendered);
+				setHtml(DOMPurify.sanitize(rendered));
 			}
 		}
 

--- a/src/app/duckerweb/components/GHScriptNode.tsx
+++ b/src/app/duckerweb/components/GHScriptNode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import DOMPurify from "dompurify";
 import { Check, Code2, Copy } from "lucide-react";
 import type { GHNodeProps, Port, ScriptData } from "../types/type";
 import { HANDLE_SIZE } from "./constants";
@@ -96,15 +97,17 @@ function ScriptCodeViewer({ script }: { script: ScriptData }) {
 				});
 
 				if (!cancelled) {
-					setHtml(rendered);
+					setHtml(DOMPurify.sanitize(rendered));
 				}
 			} catch {
 				if (!cancelled) {
 					const escaped = script.code
 						.replaceAll("&", "&amp;")
 						.replaceAll("<", "&lt;")
-						.replaceAll(">", "&gt;");
-					setHtml(`<pre>${escaped}</pre>`);
+						.replaceAll(">", "&gt;")
+						.replaceAll('"', "&quot;")
+						.replaceAll("'", "&#39;");
+					setHtml(DOMPurify.sanitize(`<pre>${escaped}</pre>`));
 				}
 			}
 		})();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements **SECURITY_AUDIT PR 5** — findings #6 and #11 (defense-in-depth).

- DOMPurify around Shiki HTML before `dangerouslySetInnerHTML` (GHScriptNode + GHJsonView)
- Hardened fallback escapes (`"`, `'`)
- Parser `extractItems` uses `Object.create(null)` and rejects `__proto__` / `constructor` / `prototype` keys
- Adds `dompurify` dependency

## Test plan
- [ ] Script node and JSON view still render highlighted code correctly
- [ ] Visual spot-check of GH script / JSON panels

Can merge anytime relative to PR1–PR4.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2801cf5a-bc6d-4114-af7f-54b7d7dc5f87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2801cf5a-bc6d-4114-af7f-54b7d7dc5f87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

