### PR TITLE
fix(security): scrub PostHog share-token leakage

### DIFF
--- a/src/app/providers/PostHogProvider.tsx
+++ b/src/app/providers/PostHogProvider.tsx
@@ -1,109 +1,8 @@
 import posthog from "posthog-js";
-import type { CaptureResult } from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { useEffect } from "react";
 import { env } from "@/env";
-
-/** Properties that are always full URLs (or URL-like) and should lose search/hash. */
-const FULL_URL_PROPERTY_KEYS = new Set([
-	"$current_url",
-	"document_url",
-	"$referrer",
-	"url",
-	"href",
-]);
-
-const TOKEN_KEY_PATTERN = /token|share_?token|shareToken/i;
-
-function scrubUrl(value: string): string {
-	try {
-		const url = new URL(value, window.location.origin);
-		url.search = "";
-		url.hash = "";
-		return url.toString();
-	} catch {
-		return value;
-	}
-}
-
-function scrubPathname(value: string): string {
-	const q = value.indexOf("?");
-	const h = value.indexOf("#");
-	if (q === -1 && h === -1) {
-		return value;
-	}
-	const cut = Math.min(
-		q === -1 ? value.length : q,
-		h === -1 ? value.length : h
-	);
-	return value.slice(0, cut);
-}
-
-function looksLikeAbsoluteUrl(value: string): boolean {
-	return /^https?:\/\//i.test(value) || value.includes("://");
-}
-
-function scrubValue(key: string, value: unknown): unknown {
-	if (TOKEN_KEY_PATTERN.test(key)) {
-		return "[redacted]";
-	}
-
-	if (typeof value === "string") {
-		if (key === "$pathname") {
-			return scrubPathname(value);
-		}
-		if (FULL_URL_PROPERTY_KEYS.has(key) || looksLikeAbsoluteUrl(value)) {
-			return scrubUrl(value);
-		}
-		// Relative paths or strings with query (e.g. "/share?token=…")
-		if (value.startsWith("/") && (value.includes("?") || value.includes("#"))) {
-			return scrubPathname(value);
-		}
-		return value;
-	}
-
-	if (Array.isArray(value)) {
-		return value.map((item, index) => scrubValue(String(index), item));
-	}
-
-	if (value !== null && typeof value === "object") {
-		return scrubProperties(value as Record<string, unknown>);
-	}
-
-	return value;
-}
-
-function scrubProperties(
-	properties: Record<string, unknown>
-): Record<string, unknown> {
-	const scrubbed: Record<string, unknown> = {};
-	for (const [key, value] of Object.entries(properties)) {
-		scrubbed[key] = scrubValue(key, value);
-	}
-	return scrubbed;
-}
-
-function scrubEvent(event: CaptureResult | null): CaptureResult | null {
-	if (!event) {
-		return event;
-	}
-
-	if (event.properties) {
-		event.properties = scrubProperties(
-			event.properties as Record<string, unknown>
-		);
-	}
-	if (event.$set) {
-		event.$set = scrubProperties(event.$set as Record<string, unknown>);
-	}
-	if (event.$set_once) {
-		event.$set_once = scrubProperties(
-			event.$set_once as Record<string, unknown>
-		);
-	}
-
-	return event;
-}
+import { scrubPostHogEvent } from "@/utils/scrub-posthog-event";
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
 	useEffect(() => {
@@ -118,7 +17,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 			capture_pageleave: true,
 			capture_exceptions: true,
 			debug: import.meta.env.DEV,
-			before_send: (event) => scrubEvent(event),
+			before_send: (event) => scrubPostHogEvent(event),
 			session_recording: {
 				// Explicitly mask all inputs; client config takes precedence over
 				// remote project masking settings.

--- a/src/app/providers/PostHogProvider.tsx
+++ b/src/app/providers/PostHogProvider.tsx
@@ -1,7 +1,109 @@
 import posthog from "posthog-js";
+import type { CaptureResult } from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { useEffect } from "react";
 import { env } from "@/env";
+
+/** Properties that are always full URLs (or URL-like) and should lose search/hash. */
+const FULL_URL_PROPERTY_KEYS = new Set([
+	"$current_url",
+	"document_url",
+	"$referrer",
+	"url",
+	"href",
+]);
+
+const TOKEN_KEY_PATTERN = /token|share_?token|shareToken/i;
+
+function scrubUrl(value: string): string {
+	try {
+		const url = new URL(value, window.location.origin);
+		url.search = "";
+		url.hash = "";
+		return url.toString();
+	} catch {
+		return value;
+	}
+}
+
+function scrubPathname(value: string): string {
+	const q = value.indexOf("?");
+	const h = value.indexOf("#");
+	if (q === -1 && h === -1) {
+		return value;
+	}
+	const cut = Math.min(
+		q === -1 ? value.length : q,
+		h === -1 ? value.length : h
+	);
+	return value.slice(0, cut);
+}
+
+function looksLikeAbsoluteUrl(value: string): boolean {
+	return /^https?:\/\//i.test(value) || value.includes("://");
+}
+
+function scrubValue(key: string, value: unknown): unknown {
+	if (TOKEN_KEY_PATTERN.test(key)) {
+		return "[redacted]";
+	}
+
+	if (typeof value === "string") {
+		if (key === "$pathname") {
+			return scrubPathname(value);
+		}
+		if (FULL_URL_PROPERTY_KEYS.has(key) || looksLikeAbsoluteUrl(value)) {
+			return scrubUrl(value);
+		}
+		// Relative paths or strings with query (e.g. "/share?token=…")
+		if (value.startsWith("/") && (value.includes("?") || value.includes("#"))) {
+			return scrubPathname(value);
+		}
+		return value;
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((item, index) => scrubValue(String(index), item));
+	}
+
+	if (value !== null && typeof value === "object") {
+		return scrubProperties(value as Record<string, unknown>);
+	}
+
+	return value;
+}
+
+function scrubProperties(
+	properties: Record<string, unknown>
+): Record<string, unknown> {
+	const scrubbed: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(properties)) {
+		scrubbed[key] = scrubValue(key, value);
+	}
+	return scrubbed;
+}
+
+function scrubEvent(event: CaptureResult | null): CaptureResult | null {
+	if (!event) {
+		return event;
+	}
+
+	if (event.properties) {
+		event.properties = scrubProperties(
+			event.properties as Record<string, unknown>
+		);
+	}
+	if (event.$set) {
+		event.$set = scrubProperties(event.$set as Record<string, unknown>);
+	}
+	if (event.$set_once) {
+		event.$set_once = scrubProperties(
+			event.$set_once as Record<string, unknown>
+		);
+	}
+
+	return event;
+}
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
 	useEffect(() => {
@@ -16,6 +118,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 			capture_pageleave: true,
 			capture_exceptions: true,
 			debug: import.meta.env.DEV,
+			before_send: (event) => scrubEvent(event),
 			session_recording: {
 				// Explicitly mask all inputs; client config takes precedence over
 				// remote project masking settings.

--- a/src/utils/scrub-posthog-event.ts
+++ b/src/utils/scrub-posthog-event.ts
@@ -1,0 +1,105 @@
+import type { CaptureResult } from "posthog-js";
+
+/** Properties that are always full URLs (or URL-like) and should lose search/hash. */
+const FULL_URL_PROPERTY_KEYS = new Set([
+	"$current_url",
+	"document_url",
+	"$referrer",
+	"url",
+	"href",
+]);
+
+const TOKEN_KEY_PATTERN = /token|share_?token|shareToken/i;
+
+function scrubUrl(value: string): string {
+	try {
+		const url = new URL(value, window.location.origin);
+		url.search = "";
+		url.hash = "";
+		return url.toString();
+	} catch {
+		return value;
+	}
+}
+
+function scrubPathname(value: string): string {
+	const q = value.indexOf("?");
+	const h = value.indexOf("#");
+	if (q === -1 && h === -1) {
+		return value;
+	}
+	const cut = Math.min(
+		q === -1 ? value.length : q,
+		h === -1 ? value.length : h
+	);
+	return value.slice(0, cut);
+}
+
+function looksLikeAbsoluteUrl(value: string): boolean {
+	return /^https?:\/\//i.test(value) || value.includes("://");
+}
+
+function scrubValue(key: string, value: unknown): unknown {
+	if (TOKEN_KEY_PATTERN.test(key)) {
+		return "[redacted]";
+	}
+
+	if (typeof value === "string") {
+		if (key === "$pathname") {
+			return scrubPathname(value);
+		}
+		if (FULL_URL_PROPERTY_KEYS.has(key) || looksLikeAbsoluteUrl(value)) {
+			return scrubUrl(value);
+		}
+		// Relative paths or strings with query (e.g. "/share?token=…")
+		if (value.startsWith("/") && (value.includes("?") || value.includes("#"))) {
+			return scrubPathname(value);
+		}
+		return value;
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((item, index) => scrubValue(String(index), item));
+	}
+
+	if (value !== null && typeof value === "object") {
+		return scrubProperties(value as Record<string, unknown>);
+	}
+
+	return value;
+}
+
+function scrubProperties(
+	properties: Record<string, unknown>
+): Record<string, unknown> {
+	const scrubbed: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(properties)) {
+		scrubbed[key] = scrubValue(key, value);
+	}
+	return scrubbed;
+}
+
+/** Strip share tokens / URL query+hash from a PostHog capture payload. */
+export function scrubPostHogEvent(
+	event: CaptureResult | null
+): CaptureResult | null {
+	if (!event) {
+		return event;
+	}
+
+	if (event.properties) {
+		event.properties = scrubProperties(
+			event.properties as Record<string, unknown>
+		);
+	}
+	if (event.$set) {
+		event.$set = scrubProperties(event.$set as Record<string, unknown>);
+	}
+	if (event.$set_once) {
+		event.$set_once = scrubProperties(
+			event.$set_once as Record<string, unknown>
+		);
+	}
+
+	return event;
+}


### PR DESCRIPTION
## Summary
Implements **SECURITY_AUDIT** finding #3 only.

- PostHog `before_send` scrubber strips URL search/hash and redacts token-like properties (keeps `capture_exceptions`)
- Share UID length stays at **10** chars (finding #7 accepted for this use case)
- Does not include `SECURITY_AUDIT.html`

## Test plan
- [ ] Open `/share?token=…` and confirm PostHog events have scrubbed URLs (no `token=` in `$current_url`)
- [ ] Create a new share — token length remains 10
- [ ] Existing share tokens still resolve