### PR TITLE
Rewrite landing around keep → share → see

### DIFF
--- a/src/app/components/landing/clip-library-demo.tsx
+++ b/src/app/components/landing/clip-library-demo.tsx
@@ -1,0 +1,159 @@
+import { AnimatePresence, motion } from "motion/react";
+import { Check, Copy, Share } from "lucide-react";
+import { useState } from "react";
+
+const SAMPLE_CLIPS = [
+	{
+		id: "facade",
+		name: "ParametricFacade",
+		description: "Panel divisions with custom depth offsets",
+		tags: ["architecture", "facade"],
+	},
+	{
+		id: "curve",
+		name: "DisplayCurveLength",
+		description: "Curve length labels with unit formatting",
+		tags: ["analysis"],
+	},
+	{
+		id: "voronoi",
+		name: "VoronoiPattern",
+		description: "Surface subdivision with attractor points",
+		tags: ["geometry"],
+	},
+] as const;
+
+type DemoMode = "preview" | "copy" | "share";
+
+/**
+ * Tiny in-page product mock: preview, or copy/share one sample clip.
+ * Not a full tour — one click, one confirmation.
+ */
+export function ClipLibraryDemo({
+	mode = "preview",
+	featuredId = "facade",
+}: {
+	mode?: DemoMode;
+	featuredId?: (typeof SAMPLE_CLIPS)[number]["id"];
+}) {
+	const [copiedId, setCopiedId] = useState<string | null>(null);
+	const [sharedId, setSharedId] = useState<string | null>(null);
+
+	const handleCopy = (id: string) => {
+		setSharedId(null);
+		setCopiedId(id);
+		window.setTimeout(() => setCopiedId((cur) => (cur === id ? null : cur)), 1800);
+	};
+
+	const handleShare = (id: string) => {
+		setCopiedId(null);
+		setSharedId(id);
+		window.setTimeout(() => setSharedId((cur) => (cur === id ? null : cur)), 2800);
+	};
+
+	return (
+		<div className="relative">
+			<ul className="flex flex-col gap-2.5">
+				{SAMPLE_CLIPS.map((clip) => {
+					const featured = clip.id === featuredId;
+					const justCopied = copiedId === clip.id;
+					const justShared = sharedId === clip.id;
+
+					return (
+						<li
+							key={clip.id}
+							className={`rounded-lg border bg-neutral-950 px-4 py-3 transition-colors ${
+								featured
+									? "border-neutral-600"
+									: "border-neutral-900 opacity-70"
+							}`}
+						>
+							<div className="flex items-start justify-between gap-3">
+								<div className="min-w-0">
+									<p className="truncate text-sm font-medium text-white">
+										{clip.name}
+									</p>
+									<p className="mt-0.5 line-clamp-1 text-xs text-neutral-500">
+										{clip.description}
+									</p>
+									<div className="mt-2 flex flex-wrap gap-1.5">
+										{clip.tags.map((tag) => (
+											<span
+												key={tag}
+												className="font-mono text-[10px] tracking-wide text-neutral-600 uppercase"
+											>
+												{tag}
+											</span>
+										))}
+									</div>
+								</div>
+								{featured && mode === "copy" && (
+									<button
+										type="button"
+										onClick={() => handleCopy(clip.id)}
+										className={`inline-flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors ${
+											justCopied
+												? "bg-white text-black"
+												: "bg-neutral-900 text-neutral-300 hover:bg-neutral-800 hover:text-white"
+										}`}
+									>
+										{justCopied ? (
+											<>
+												<Check className="h-3.5 w-3.5" />
+												copied
+											</>
+										) : (
+											<>
+												<Copy className="h-3.5 w-3.5" />
+												copy
+											</>
+										)}
+									</button>
+								)}
+								{featured && mode === "share" && (
+									<button
+										type="button"
+										onClick={() => handleShare(clip.id)}
+										className={`inline-flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors ${
+											justShared
+												? "bg-white text-black"
+												: "bg-neutral-900 text-neutral-300 hover:bg-neutral-800 hover:text-white"
+										}`}
+									>
+										{justShared ? (
+											<>
+												<Check className="h-3.5 w-3.5" />
+												shared
+											</>
+										) : (
+											<>
+												<Share className="h-3.5 w-3.5" />
+												share
+											</>
+										)}
+									</button>
+								)}
+							</div>
+						</li>
+					);
+				})}
+			</ul>
+
+			<AnimatePresence>
+				{sharedId && (
+					<motion.div
+						initial={{ opacity: 0, y: 8 }}
+						animate={{ opacity: 1, y: 0 }}
+						exit={{ opacity: 0, y: 4 }}
+						transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
+						className="absolute inset-x-0 -bottom-14 flex justify-center"
+					>
+						<div className="rounded-md border border-neutral-800 bg-neutral-950 px-3 py-2 font-mono text-xs text-neutral-300">
+							hopperclip.com/share?…
+						</div>
+					</motion.div>
+				)}
+			</AnimatePresence>
+		</div>
+	);
+}

--- a/src/app/components/landing/clip-library-demo.tsx
+++ b/src/app/components/landing/clip-library-demo.tsx
@@ -1,5 +1,4 @@
 import { AnimatePresence, motion } from "motion/react";
-import { Check, Copy, Share } from "lucide-react";
 import { useState } from "react";
 
 const SAMPLE_CLIPS = [
@@ -27,7 +26,7 @@ type DemoMode = "preview" | "copy" | "share";
 
 /**
  * Tiny in-page product mock: preview, or copy/share one sample clip.
- * Not a full tour — one click, one confirmation.
+ * Uses Hopper Card accents (green-300 Shared, tag chips) — not a full tour.
  */
 export function ClipLibraryDemo({
 	mode = "preview",
@@ -58,29 +57,38 @@ export function ClipLibraryDemo({
 					const featured = clip.id === featuredId;
 					const justCopied = copiedId === clip.id;
 					const justShared = sharedId === clip.id;
+					const showSharedBadge =
+						(mode === "preview" && clip.id === "facade") || justShared;
 
 					return (
 						<li
 							key={clip.id}
-							className={`rounded-lg border bg-neutral-950 px-4 py-3 transition-colors ${
+							className={`relative rounded-md p-3 ring-1 transition-colors ${
 								featured
-									? "border-neutral-600"
-									: "border-neutral-900 opacity-70"
+									? "bg-neutral-900 ring-neutral-500"
+									: "bg-neutral-950 ring-neutral-800 opacity-70"
 							}`}
 						>
+							{showSharedBadge && (
+								<span className="absolute top-2.5 right-2.5 rounded-md bg-green-300 px-2 text-xs font-bold text-neutral-800">
+									Shared
+								</span>
+							)}
 							<div className="flex items-start justify-between gap-3">
-								<div className="min-w-0">
-									<p className="truncate text-sm font-medium text-white">
+								<div
+									className={`min-w-0 ${showSharedBadge ? "pr-16" : ""}`}
+								>
+									<p className="truncate text-sm font-semibold text-white">
 										{clip.name}
 									</p>
-									<p className="mt-0.5 line-clamp-1 text-xs text-neutral-500">
+									<p className="mt-0.5 line-clamp-1 text-xs text-neutral-400">
 										{clip.description}
 									</p>
 									<div className="mt-2 flex flex-wrap gap-1.5">
 										{clip.tags.map((tag) => (
 											<span
 												key={tag}
-												className="font-mono text-[10px] tracking-wide text-neutral-600 uppercase"
+												className="rounded-sm bg-neutral-600 px-2 text-xs font-semibold text-neutral-100"
 											>
 												{tag}
 											</span>
@@ -91,46 +99,22 @@ export function ClipLibraryDemo({
 									<button
 										type="button"
 										onClick={() => handleCopy(clip.id)}
-										className={`inline-flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors ${
+										className={`shrink-0 px-2 text-sm font-bold transition-colors ${
 											justCopied
-												? "bg-white text-black"
-												: "bg-neutral-900 text-neutral-300 hover:bg-neutral-800 hover:text-white"
+												? "rounded-md bg-green-300 text-neutral-800"
+												: "text-neutral-400 hover:text-neutral-50"
 										}`}
 									>
-										{justCopied ? (
-											<>
-												<Check className="h-3.5 w-3.5" />
-												copied
-											</>
-										) : (
-											<>
-												<Copy className="h-3.5 w-3.5" />
-												copy
-											</>
-										)}
+										{justCopied ? "copied!" : "copy"}
 									</button>
 								)}
-								{featured && mode === "share" && (
+								{featured && mode === "share" && !justShared && (
 									<button
 										type="button"
 										onClick={() => handleShare(clip.id)}
-										className={`inline-flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors ${
-											justShared
-												? "bg-white text-black"
-												: "bg-neutral-900 text-neutral-300 hover:bg-neutral-800 hover:text-white"
-										}`}
+										className="shrink-0 px-2 text-sm font-bold text-neutral-400 transition-colors hover:text-neutral-50"
 									>
-										{justShared ? (
-											<>
-												<Check className="h-3.5 w-3.5" />
-												shared
-											</>
-										) : (
-											<>
-												<Share className="h-3.5 w-3.5" />
-												share
-											</>
-										)}
+										share
 									</button>
 								)}
 							</div>
@@ -148,7 +132,7 @@ export function ClipLibraryDemo({
 						transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
 						className="absolute inset-x-0 -bottom-14 flex justify-center"
 					>
-						<div className="rounded-md border border-neutral-800 bg-neutral-950 px-3 py-2 font-mono text-xs text-neutral-300">
+						<div className="rounded-md border border-green-300/30 bg-neutral-950 px-3 py-2 font-mono text-xs text-green-300">
 							hopperclip.com/share?…
 						</div>
 					</motion.div>

--- a/src/app/components/landing/inspect-diff-visual.tsx
+++ b/src/app/components/landing/inspect-diff-visual.tsx
@@ -47,7 +47,7 @@ export function InspectDiffVisual() {
 				<motion.path
 					d="M 118 150 C 160 150, 160 110, 190 110"
 					fill="none"
-					stroke="#4ade80"
+					stroke="#86efac"
 					strokeWidth="2"
 					initial={{ pathLength: 0, opacity: 0 }}
 					whileInView={{ pathLength: 1, opacity: 1 }}
@@ -192,7 +192,7 @@ export function InspectDiffVisual() {
 						height="44"
 						rx="4"
 						fill="#171717"
-						stroke="#4ade80"
+						stroke="#86efac"
 						strokeWidth="2"
 					/>
 					<text
@@ -217,13 +217,13 @@ export function InspectDiffVisual() {
 			</svg>
 
 			<div className="absolute right-3 bottom-3 flex gap-2 font-mono text-[10px] tracking-wide uppercase">
-				<span className="rounded border border-neutral-800 bg-neutral-950/90 px-1.5 py-0.5 text-green-400">
+				<span className="rounded bg-green-300 px-1.5 py-0.5 font-bold text-neutral-800">
 					+ added
 				</span>
-				<span className="rounded border border-neutral-800 bg-neutral-950/90 px-1.5 py-0.5 text-amber-300">
+				<span className="rounded border border-neutral-700 bg-neutral-950/90 px-1.5 py-0.5 text-amber-300">
 					~ modified
 				</span>
-				<span className="rounded border border-neutral-800 bg-neutral-950/90 px-1.5 py-0.5 text-red-400">
+				<span className="rounded border border-neutral-700 bg-neutral-950/90 px-1.5 py-0.5 text-red-400">
 					− removed
 				</span>
 			</div>

--- a/src/app/components/landing/inspect-diff-visual.tsx
+++ b/src/app/components/landing/inspect-diff-visual.tsx
@@ -1,0 +1,232 @@
+import { motion } from "motion/react";
+
+/**
+ * Quiet product frame for the LP: graph + soft diff highlight.
+ * Dark palette to match the landing page — not the real GH canvas look.
+ */
+export function InspectDiffVisual() {
+	return (
+		<div
+			className="relative overflow-hidden rounded-xl border border-neutral-800 bg-neutral-950"
+			aria-hidden
+		>
+			<svg
+				viewBox="0 0 480 220"
+				className="h-auto w-full"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<defs>
+					<pattern
+						id="lp-gh-grid"
+						width="40"
+						height="40"
+						patternUnits="userSpaceOnUse"
+					>
+						<path
+							d="M 40 0 L 0 0 0 40"
+							fill="none"
+							stroke="#262626"
+							strokeWidth="1"
+						/>
+					</pattern>
+				</defs>
+				<rect width="480" height="220" fill="#0a0a0a" />
+				<rect width="480" height="220" fill="url(#lp-gh-grid)" />
+
+				{/* wires */}
+				<motion.path
+					d="M 118 70 C 160 70, 160 70, 190 70"
+					fill="none"
+					stroke="#525252"
+					strokeWidth="1.5"
+					initial={{ pathLength: 0 }}
+					whileInView={{ pathLength: 1 }}
+					viewport={{ once: true }}
+					transition={{ duration: 0.8, delay: 0.2 }}
+				/>
+				<motion.path
+					d="M 118 150 C 160 150, 160 110, 190 110"
+					fill="none"
+					stroke="#4ade80"
+					strokeWidth="2"
+					initial={{ pathLength: 0, opacity: 0 }}
+					whileInView={{ pathLength: 1, opacity: 1 }}
+					viewport={{ once: true }}
+					transition={{ duration: 0.9, delay: 0.55 }}
+				/>
+				<motion.path
+					d="M 300 90 C 340 90, 340 150, 362 150"
+					fill="none"
+					stroke="#f87171"
+					strokeWidth="1.5"
+					strokeDasharray="4 3"
+					initial={{ opacity: 0 }}
+					whileInView={{ opacity: 0.85 }}
+					viewport={{ once: true }}
+					transition={{ duration: 0.5, delay: 0.7 }}
+				/>
+
+				{/* value nodes */}
+				<g transform="translate(48, 48)">
+					<rect
+						width="70"
+						height="44"
+						rx="4"
+						fill="#262626"
+						stroke="#525252"
+					/>
+					<text
+						x="10"
+						y="18"
+						fontSize="9"
+						fill="#737373"
+						fontFamily="ui-monospace, monospace"
+					>
+						Number
+					</text>
+					<text
+						x="10"
+						y="34"
+						fontSize="11"
+						fill="#e5e5e5"
+						fontFamily="ui-sans-serif, system-ui"
+					>
+						12.0
+					</text>
+				</g>
+
+				<g transform="translate(48, 128)">
+					<rect
+						width="70"
+						height="44"
+						rx="4"
+						fill="#262626"
+						stroke="#525252"
+					/>
+					<text
+						x="10"
+						y="18"
+						fontSize="9"
+						fill="#737373"
+						fontFamily="ui-monospace, monospace"
+					>
+						Number
+					</text>
+					<text
+						x="10"
+						y="34"
+						fontSize="11"
+						fill="#e5e5e5"
+						fontFamily="ui-sans-serif, system-ui"
+					>
+						4.0
+					</text>
+				</g>
+
+				{/* component — unmodified */}
+				<g transform="translate(190, 48)">
+					<rect
+						width="110"
+						height="64"
+						rx="4"
+						fill="#171717"
+						stroke="#404040"
+					/>
+					<rect width="110" height="18" rx="4" fill="#262626" />
+					<rect y="14" width="110" height="8" fill="#262626" />
+					<text
+						x="8"
+						y="13"
+						fontSize="9"
+						fill="#d4d4d4"
+						fontFamily="ui-sans-serif, system-ui"
+					>
+						Divide Curve
+					</text>
+					<circle cx="0" cy="22" r="4" fill="#525252" />
+					<circle cx="0" cy="42" r="4" fill="#525252" />
+					<circle cx="110" cy="32" r="4" fill="#525252" />
+				</g>
+
+				{/* component — modified */}
+				<motion.g
+					transform="translate(190, 128)"
+					initial={{ opacity: 0.35 }}
+					whileInView={{ opacity: 1 }}
+					viewport={{ once: true }}
+					transition={{ duration: 0.6, delay: 0.45 }}
+				>
+					<rect
+						width="110"
+						height="52"
+						rx="4"
+						fill="#171717"
+						stroke="#fbbf24"
+						strokeWidth="2"
+					/>
+					<rect width="110" height="18" rx="4" fill="#262626" />
+					<rect y="14" width="110" height="8" fill="#262626" />
+					<text
+						x="8"
+						y="13"
+						fontSize="9"
+						fill="#d4d4d4"
+						fontFamily="ui-sans-serif, system-ui"
+					>
+						Extrude
+					</text>
+					<circle cx="0" cy="28" r="4" fill="#525252" />
+					<circle cx="110" cy="28" r="4" fill="#525252" />
+				</motion.g>
+
+				{/* panel — added */}
+				<motion.g
+					transform="translate(362, 128)"
+					initial={{ opacity: 0, y: 6 }}
+					whileInView={{ opacity: 1, y: 0 }}
+					viewport={{ once: true }}
+					transition={{ duration: 0.5, delay: 0.75 }}
+				>
+					<rect
+						width="70"
+						height="44"
+						rx="4"
+						fill="#171717"
+						stroke="#4ade80"
+						strokeWidth="2"
+					/>
+					<text
+						x="10"
+						y="18"
+						fontSize="9"
+						fill="#737373"
+						fontFamily="ui-monospace, monospace"
+					>
+						Panel
+					</text>
+					<text
+						x="10"
+						y="34"
+						fontSize="10"
+						fill="#e5e5e5"
+						fontFamily="ui-sans-serif, system-ui"
+					>
+						ok
+					</text>
+				</motion.g>
+			</svg>
+
+			<div className="absolute right-3 bottom-3 flex gap-2 font-mono text-[10px] tracking-wide uppercase">
+				<span className="rounded border border-neutral-800 bg-neutral-950/90 px-1.5 py-0.5 text-green-400">
+					+ added
+				</span>
+				<span className="rounded border border-neutral-800 bg-neutral-950/90 px-1.5 py-0.5 text-amber-300">
+					~ modified
+				</span>
+				<span className="rounded border border-neutral-800 bg-neutral-950/90 px-1.5 py-0.5 text-red-400">
+					− removed
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -5,24 +5,20 @@ import {
 	redirect,
 	useNavigate,
 } from "@tanstack/react-router";
-import {
-	ArrowRight,
-	GitCompareArrows,
-	MessageSquare,
-	MousePointerClick,
-	Plug,
-} from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import { useEffect } from "react";
 import { motion, useScroll, useTransform } from "motion/react";
 import { AuthLoadingScreen } from "@/app/components/auth-loading-screen";
 import Footer from "@/app/components/footer";
 import Header from "@/app/components/header";
+import { ClipLibraryDemo } from "@/app/components/landing/clip-library-demo";
+import { InspectDiffVisual } from "@/app/components/landing/inspect-diff-visual";
 import { Reveal } from "@/app/components/landing/reveal";
 import { fetchClerkAuth } from "./__root";
 
 export const Route = createFileRoute("/")({
 	head: () => ({
-		meta: [{ title: "Hopper Clip — Grasshopper, sorted" }],
+		meta: [{ title: "Hopper Clip — Grasshopper snippets, ready" }],
 	}),
 	beforeLoad: async () => {
 		const { userId } = await fetchClerkAuth();
@@ -81,91 +77,203 @@ function SignedInLandingContent() {
 	);
 }
 
-const cases = [
-	{
-		icon: MessageSquare,
-		eyebrow: "Share for review",
-		title: "Send one link instead of an attachment.",
-		body: "Drop a .gh, get a URL. Reviewers open it in any browser — no Rhino, no plugins, no setup. Comments stay in your existing tools.",
-	},
-	{
-		icon: MousePointerClick,
-		eyebrow: "Inspect without Rhino",
-		title: "Read the whole graph at a glance.",
-		body: "Pan and zoom every component, wire, slider, and panel. Switch to a flat list for an inventory, or JSON for the raw structure.",
-	},
-	{
-		icon: GitCompareArrows,
-		eyebrow: "Diff between versions",
-		title: "See what changed, not what's there.",
-		body: "Drop in a second file to compare two versions. Added, removed, modified, and rewired components are highlighted — wire by wire.",
-	},
-];
-
 function LandingPageContent() {
 	return (
 		<>
-			<div className="mx-auto flex w-full max-w-6xl flex-1 flex-col justify-center gap-8 min-[2200px]:max-w-[140rem] min-[2200px]:gap-20 2xl:max-w-[100rem] 2xl:gap-14">
-				<div className="min-[2200px]:grid-cols-[minmax(0,1fr)_32rem] xl:grid xl:grid-cols-[minmax(0,1fr)_22rem] xl:items-end xl:gap-12 2xl:grid-cols-[minmax(0,1fr)_28rem] 2xl:gap-16">
-					<section className="flex w-full flex-col gap-5 pt-6 pb-4 min-[2200px]:pt-28 min-[2200px]:pb-20 md:pt-10 md:pb-6 2xl:gap-7 2xl:pt-20 2xl:pb-16">
-						<Reveal>
-							<span className="font-mono text-xs tracking-[0.2em] text-neutral-600 uppercase 2xl:text-sm">
-								for individuals &amp; teams
-							</span>
-						</Reveal>
-						<Reveal delay={0.05}>
-							<div>
-								<h1 className="max-w-2xl text-4xl leading-[1.05] font-semibold tracking-tight min-[2200px]:text-8xl md:text-6xl 2xl:max-w-3xl 2xl:text-7xl">
-									Grasshopper, reviewed.
-								</h1>
-								<p className="mt-3 max-w-xl text-base text-neutral-400 min-[2200px]:text-2xl md:text-lg 2xl:mt-5 2xl:max-w-2xl 2xl:text-xl">
-									Organize your own Grasshopper definitions. Share them with a
-									team to inspect, compare, and review across versions — without
-									anyone needing Rhino in front of them.
-								</p>
-							</div>
-						</Reveal>
-						<Reveal delay={0.1}>
-							<div className="flex flex-wrap items-center gap-3 pt-1 2xl:gap-4">
-								<SignUpButton mode="modal">
-									<button
-										type="button"
-										className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-black transition-all hover:bg-neutral-200 2xl:px-7 2xl:py-3.5 2xl:text-base"
-									>
-										Get started
-										<ArrowRight className="h-4 w-4" />
-									</button>
-								</SignUpButton>
-							</div>
-							<p className="mt-3 flex items-center gap-2 text-base text-neutral-400 2xl:text-lg">
-								<Plug className="h-4 w-4 shrink-0" />
-								Nothing to install — no Rhino, no plugins, no setup for whoever
-								opens the link.
-							</p>
-						</Reveal>
-					</section>
-
-					<div className="hidden pt-6 pb-4 min-[2200px]:pt-28 min-[2200px]:pb-20 md:pt-10 md:pb-6 xl:block 2xl:pt-20 2xl:pb-16">
-						<Reveal delay={0.12}>
-							<DuckerWebCard variant="aside" />
-						</Reveal>
-					</div>
-				</div>
-
-				<section className="grid w-full grid-cols-1 gap-4 py-2 min-[2200px]:gap-10 md:grid-cols-3 2xl:gap-8 2xl:py-2">
-					{cases.map((c, i) => (
-						<Reveal key={c.eyebrow} delay={i * 0.08}>
-							<CaseCard {...c} />
-						</Reveal>
-					))}
-				</section>
-
-				<div className="xl:hidden">
-					<DuckerWebSection />
-				</div>
+			<div className="mx-auto flex w-full max-w-6xl flex-1 flex-col min-[2200px]:max-w-[140rem] 2xl:max-w-[100rem]">
+				<Hero />
+				<PersonalBeat />
+				<ShareBeat />
+				<InspectBeat />
+				<Closing />
 			</div>
 			<BottomFade />
 		</>
+	);
+}
+
+function Hero() {
+	return (
+		<section className="grid w-full grid-cols-1 items-end gap-8 pt-8 pb-12 md:pt-12 md:pb-16 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:gap-12 xl:gap-14 2xl:pt-16 2xl:pb-20">
+			<div className="flex flex-col gap-4">
+				<Reveal>
+					<h1 className="text-5xl leading-[0.95] font-semibold tracking-tight md:text-7xl 2xl:text-8xl">
+						Hopper Clip
+					</h1>
+				</Reveal>
+				<Reveal delay={0.05}>
+					<p className="max-w-xl text-xl leading-snug font-medium text-neutral-200 md:text-2xl 2xl:text-3xl">
+						Your Grasshopper snippets, ready when you need them.
+					</p>
+				</Reveal>
+				<Reveal delay={0.1}>
+					<p className="max-w-lg text-base text-neutral-400 md:text-lg">
+						Keep the definitions you paste over and over. Find them in seconds —
+						then share or inspect without hunting folders.
+					</p>
+				</Reveal>
+				<Reveal delay={0.15}>
+					<div className="pt-1">
+						<SignUpButton mode="modal">
+							<button
+								type="button"
+								className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-black transition-all hover:bg-neutral-200 2xl:px-7 2xl:py-3.5 2xl:text-base"
+							>
+								Get started
+								<ArrowRight className="h-4 w-4" />
+							</button>
+						</SignUpButton>
+					</div>
+				</Reveal>
+			</div>
+
+			<Reveal delay={0.12}>
+				<div className="rounded-2xl border border-neutral-800 bg-neutral-950/80 p-5 2xl:p-7">
+					<p className="mb-4 font-mono text-[10px] tracking-[0.18em] text-neutral-600 uppercase">
+						your library
+					</p>
+					<ClipLibraryDemo mode="preview" />
+				</div>
+			</Reveal>
+		</section>
+	);
+}
+
+function PersonalBeat() {
+	return (
+		<section className="border-t border-neutral-900 py-12 md:py-16">
+			<div className="grid grid-cols-1 items-center gap-8 md:grid-cols-2 md:gap-10">
+				<Reveal>
+					<div className="max-w-md">
+						<p className="font-mono text-xs tracking-[0.2em] text-neutral-600 uppercase">
+							For you first
+						</p>
+						<h2 className="mt-3 text-2xl font-semibold tracking-tight md:text-3xl 2xl:text-4xl">
+							A personal clip library for the scripts you reuse.
+						</h2>
+						<p className="mt-3 text-sm leading-relaxed text-neutral-400 md:text-base">
+							Paste or drop a definition, tag it, find it later. One click copies
+							it back into Grasshopper — no digging through project folders.
+						</p>
+					</div>
+				</Reveal>
+				<Reveal delay={0.08}>
+					<div className="rounded-2xl border border-neutral-800 bg-neutral-950/80 p-5 md:p-6">
+						<p className="mb-4 font-mono text-[10px] tracking-[0.18em] text-neutral-600 uppercase">
+							try copy
+						</p>
+						<ClipLibraryDemo mode="copy" featuredId="curve" />
+					</div>
+				</Reveal>
+			</div>
+		</section>
+	);
+}
+
+function ShareBeat() {
+	return (
+		<section className="border-t border-neutral-900 py-12 md:py-16">
+			<div className="grid grid-cols-1 items-center gap-8 md:grid-cols-2 md:gap-10">
+				<Reveal className="order-2 md:order-1">
+					<div className="rounded-2xl border border-neutral-800 bg-neutral-950/80 p-5 pb-14 md:p-6 md:pb-14">
+						<p className="mb-4 font-mono text-[10px] tracking-[0.18em] text-neutral-600 uppercase">
+							try share
+						</p>
+						<ClipLibraryDemo mode="share" featuredId="facade" />
+					</div>
+				</Reveal>
+				<Reveal delay={0.08} className="order-1 md:order-2">
+					<div className="max-w-md md:ml-auto">
+						<p className="font-mono text-xs tracking-[0.2em] text-neutral-600 uppercase">
+							Then the team
+						</p>
+						<h2 className="mt-3 text-2xl font-semibold tracking-tight md:text-3xl 2xl:text-4xl">
+							Share a link. Skip the file ritual.
+						</h2>
+						<p className="mt-3 text-sm leading-relaxed text-neutral-400 md:text-base">
+							No export, attach, download, open. Hit share, send the URL — your
+							teammate opens it in a browser.
+						</p>
+					</div>
+				</Reveal>
+			</div>
+		</section>
+	);
+}
+
+function InspectBeat() {
+	return (
+		<section className="border-t border-neutral-900 py-12 md:py-16">
+			<div className="grid grid-cols-1 items-center gap-8 lg:grid-cols-2 lg:gap-10">
+				<Reveal>
+					<div className="max-w-md">
+						<p className="font-mono text-xs tracking-[0.2em] text-neutral-600 uppercase">
+							See without Rhino
+						</p>
+						<h2 className="mt-3 text-2xl font-semibold tracking-tight md:text-3xl 2xl:text-4xl">
+							Inspect the graph. Diff what changed.
+						</h2>
+						<p className="mt-3 text-sm leading-relaxed text-neutral-400 md:text-base">
+							<span className="font-medium text-neutral-200">DuckerWeb</span>{" "}
+							reads the graph in your browser — pan, zoom, or diff two versions.
+							Built into Hopper Clip; free on its own.
+						</p>
+						<Link
+							to="/duckerweb"
+							className="mt-4 inline-flex items-center gap-1.5 text-sm text-neutral-300 underline-offset-4 hover:text-white hover:underline"
+						>
+							Open DuckerWeb
+							<ArrowRight className="h-3.5 w-3.5" />
+						</Link>
+					</div>
+				</Reveal>
+				<Reveal delay={0.08}>
+					<InspectDiffVisual />
+				</Reveal>
+			</div>
+		</section>
+	);
+}
+
+function Closing() {
+	return (
+		<section className="border-t border-neutral-900 py-12 md:py-16">
+			<Reveal>
+				<div className="mx-auto max-w-2xl text-center">
+					<h2 className="text-2xl font-semibold tracking-tight md:text-4xl">
+						Keep. Share. See.
+					</h2>
+					<p className="mt-3 text-base text-neutral-400 md:text-lg">
+						Your snippets stay organized. Your team gets a link. Anyone can read
+						the script without opening Grasshopper.
+					</p>
+					<div className="mt-6 flex flex-col items-center gap-3">
+						<SignUpButton mode="modal">
+							<button
+								type="button"
+								className="inline-flex items-center gap-2 rounded-full bg-white px-7 py-3.5 text-sm font-semibold text-black transition-all hover:bg-neutral-200 md:text-base"
+							>
+								Get started
+								<ArrowRight className="h-4 w-4" />
+							</button>
+						</SignUpButton>
+						<p className="text-sm text-neutral-500">
+							Just need a quick look?{" "}
+							<Link
+								to="/duckerweb"
+								className="text-neutral-300 underline-offset-4 hover:text-white hover:underline"
+							>
+								Open DuckerWeb
+							</Link>
+							<span className="text-neutral-600">
+								{" "}
+								— free viewer, no account.
+							</span>
+						</p>
+					</div>
+				</div>
+			</Reveal>
+		</section>
 	);
 }
 
@@ -178,123 +286,5 @@ function BottomFade() {
 			aria-hidden
 			className="pointer-events-none fixed inset-x-0 bottom-0 z-30 h-24 bg-gradient-to-b from-transparent to-black"
 		/>
-	);
-}
-
-function DuckerWebSection() {
-	return (
-		<section className="mt-10 w-full pb-4 md:mt-12 2xl:mt-16">
-			<Reveal>
-				<DuckerWebCard variant="banner" />
-			</Reveal>
-		</section>
-	);
-}
-
-function DuckerWebCard({ variant }: { variant: "aside" | "banner" }) {
-	if (variant === "aside") {
-		return (
-			<div className="rounded-2xl border border-neutral-800 bg-gradient-to-b from-neutral-950 to-black p-6 2xl:p-10">
-				<div className="font-mono text-xs tracking-[0.2em] text-neutral-500 uppercase 2xl:text-sm">
-					// also from hopper clip
-				</div>
-				<h2 className="mt-3 text-lg leading-snug font-semibold tracking-tight 2xl:text-xl">
-					Look at a definition without opening Rhino.
-				</h2>
-				<p className="mt-2 text-sm leading-relaxed text-neutral-400 2xl:text-base">
-					<span className="font-medium text-neutral-200">DuckerWeb</span> is our
-					free browser viewer — drop a{" "}
-					<code className="rounded bg-neutral-900 px-1 py-0.5 font-mono text-xs text-neutral-300">
-						.gh
-					</code>
-					, no account needed.
-				</p>
-				<Link
-					to="/duckerweb"
-					className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-full bg-white px-5 py-2.5 text-sm font-semibold text-black transition-all hover:bg-neutral-200"
-				>
-					Open DuckerWeb
-					<ArrowRight className="h-4 w-4" />
-				</Link>
-				<p className="mt-2 text-center text-xs text-neutral-500">
-					free · runs locally in your browser
-				</p>
-			</div>
-		);
-	}
-
-	return (
-		<div className="overflow-hidden rounded-2xl border border-neutral-800 bg-gradient-to-b from-neutral-950 to-black">
-			<div className="flex flex-col gap-5 p-6 min-[2200px]:p-16 md:flex-row md:items-center md:justify-between md:p-8 2xl:gap-10 2xl:p-14">
-				<div className="max-w-xl">
-					<div className="font-mono text-xs tracking-[0.2em] text-neutral-500 uppercase 2xl:text-sm">
-						// also from hopper clip
-					</div>
-					<h2 className="mt-3 text-2xl font-semibold tracking-tight md:text-3xl 2xl:text-4xl">
-						Look at a definition without opening Rhino.
-					</h2>
-					<p className="mt-3 text-sm leading-relaxed text-neutral-400 md:text-base 2xl:text-lg">
-						<span className="font-medium text-neutral-200">DuckerWeb</span> is
-						our free, browser-only viewer. Drop a{" "}
-						<code className="rounded bg-neutral-900 px-1 py-0.5 font-mono text-xs text-neutral-300">
-							.gh
-						</code>
-						, paste GhXml, or compare two versions side-by-side — everything
-						runs locally in your browser, nothing uploaded, no account required.
-					</p>
-					<div className="mt-4 flex flex-wrap gap-2">
-						<Pill>No Rhino</Pill>
-						<Pill>No Grasshopper</Pill>
-						<Pill>No sign-up</Pill>
-						<Pill>Runs locally</Pill>
-					</div>
-				</div>
-				<div className="flex shrink-0 flex-col items-start gap-2 md:items-end">
-					<Link
-						to="/duckerweb"
-						className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-black transition-all hover:bg-neutral-200 2xl:px-7 2xl:py-3.5 2xl:text-base"
-					>
-						Open DuckerWeb
-						<ArrowRight className="h-4 w-4" />
-					</Link>
-					<span className="text-xs text-neutral-500">
-						free · no account needed
-					</span>
-				</div>
-			</div>
-		</div>
-	);
-}
-
-function Pill({ children }: { children: React.ReactNode }) {
-	return (
-		<span className="rounded-full border border-neutral-800 bg-neutral-900 px-3 py-1 text-xs font-medium text-neutral-400">
-			{children}
-		</span>
-	);
-}
-
-function CaseCard({
-	icon: Icon,
-	eyebrow,
-	title,
-	body,
-}: {
-	icon: React.ComponentType<{ className?: string }>;
-	eyebrow: string;
-	title: string;
-	body: string;
-}) {
-	return (
-		<div className="flex h-full flex-col gap-3 rounded-xl border border-neutral-900 bg-neutral-950 p-6 transition-colors hover:border-neutral-700 min-[2200px]:gap-7 min-[2200px]:p-12 2xl:gap-6 2xl:p-10">
-			<Icon className="h-5 w-5 text-neutral-400 min-[2200px]:h-8 min-[2200px]:w-8 2xl:h-7 2xl:w-7" />
-			<div className="font-mono text-xs tracking-[0.18em] text-neutral-500 uppercase">
-				{eyebrow}
-			</div>
-			<h3 className="text-lg leading-snug font-semibold 2xl:text-xl">
-				{title}
-			</h3>
-			<p className="text-sm text-neutral-400 2xl:text-base">{body}</p>
-		</div>
 	);
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -97,23 +97,19 @@ function Hero() {
 		<section className="grid w-full grid-cols-1 items-end gap-8 pt-8 pb-12 md:pt-12 md:pb-16 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:gap-12 xl:gap-14 2xl:pt-16 2xl:pb-20">
 			<div className="flex flex-col gap-4">
 				<Reveal>
-					<h1 className="text-5xl leading-[0.95] font-semibold tracking-tight md:text-7xl 2xl:text-8xl">
-						Hopper{" "}
-						<span className="text-green-300">Clip</span>
+					<h1 className="max-w-2xl text-4xl leading-[1.05] font-semibold tracking-tight md:text-6xl 2xl:text-7xl">
+						Your Grasshopper snippets,{" "}
+						<span className="text-green-300">ready</span> when you need
+						them.
 					</h1>
 				</Reveal>
 				<Reveal delay={0.05}>
-					<p className="max-w-xl text-xl leading-snug font-medium text-neutral-200 md:text-2xl 2xl:text-3xl">
-						Your Grasshopper snippets, ready when you need them.
-					</p>
-				</Reveal>
-				<Reveal delay={0.1}>
 					<p className="max-w-lg text-base text-neutral-400 md:text-lg">
 						Keep the definitions you paste over and over. Find them in seconds —
 						then share or inspect without hunting folders.
 					</p>
 				</Reveal>
-				<Reveal delay={0.15}>
+				<Reveal delay={0.1}>
 					<div className="pt-1">
 						<SignUpButton mode="modal">
 							<button

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -98,7 +98,8 @@ function Hero() {
 			<div className="flex flex-col gap-4">
 				<Reveal>
 					<h1 className="text-5xl leading-[0.95] font-semibold tracking-tight md:text-7xl 2xl:text-8xl">
-						Hopper Clip
+						Hopper{" "}
+						<span className="text-green-300">Clip</span>
 					</h1>
 				</Reveal>
 				<Reveal delay={0.05}>
@@ -117,7 +118,7 @@ function Hero() {
 						<SignUpButton mode="modal">
 							<button
 								type="button"
-								className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-black transition-all hover:bg-neutral-200 2xl:px-7 2xl:py-3.5 2xl:text-base"
+								className="inline-flex items-center gap-2 rounded-full bg-green-300 px-6 py-3 text-sm font-semibold text-neutral-800 transition-all hover:bg-green-200 2xl:px-7 2xl:py-3.5 2xl:text-base"
 							>
 								Get started
 								<ArrowRight className="h-4 w-4" />
@@ -129,7 +130,7 @@ function Hero() {
 
 			<Reveal delay={0.12}>
 				<div className="rounded-2xl border border-neutral-800 bg-neutral-950/80 p-5 2xl:p-7">
-					<p className="mb-4 font-mono text-[10px] tracking-[0.18em] text-neutral-600 uppercase">
+					<p className="mb-4 font-mono text-[10px] tracking-[0.18em] text-green-300/70 uppercase">
 						your library
 					</p>
 					<ClipLibraryDemo mode="preview" />
@@ -145,7 +146,7 @@ function PersonalBeat() {
 			<div className="grid grid-cols-1 items-center gap-8 md:grid-cols-2 md:gap-10">
 				<Reveal>
 					<div className="max-w-md">
-						<p className="font-mono text-xs tracking-[0.2em] text-neutral-600 uppercase">
+						<p className="font-mono text-xs tracking-[0.2em] text-green-300/80 uppercase">
 							For you first
 						</p>
 						<h2 className="mt-3 text-2xl font-semibold tracking-tight md:text-3xl 2xl:text-4xl">
@@ -159,7 +160,7 @@ function PersonalBeat() {
 				</Reveal>
 				<Reveal delay={0.08}>
 					<div className="rounded-2xl border border-neutral-800 bg-neutral-950/80 p-5 md:p-6">
-						<p className="mb-4 font-mono text-[10px] tracking-[0.18em] text-neutral-600 uppercase">
+						<p className="mb-4 font-mono text-[10px] tracking-[0.18em] text-green-300/70 uppercase">
 							try copy
 						</p>
 						<ClipLibraryDemo mode="copy" featuredId="curve" />
@@ -176,7 +177,7 @@ function ShareBeat() {
 			<div className="grid grid-cols-1 items-center gap-8 md:grid-cols-2 md:gap-10">
 				<Reveal className="order-2 md:order-1">
 					<div className="rounded-2xl border border-neutral-800 bg-neutral-950/80 p-5 pb-14 md:p-6 md:pb-14">
-						<p className="mb-4 font-mono text-[10px] tracking-[0.18em] text-neutral-600 uppercase">
+						<p className="mb-4 font-mono text-[10px] tracking-[0.18em] text-green-300/70 uppercase">
 							try share
 						</p>
 						<ClipLibraryDemo mode="share" featuredId="facade" />
@@ -184,7 +185,7 @@ function ShareBeat() {
 				</Reveal>
 				<Reveal delay={0.08} className="order-1 md:order-2">
 					<div className="max-w-md md:ml-auto">
-						<p className="font-mono text-xs tracking-[0.2em] text-neutral-600 uppercase">
+						<p className="font-mono text-xs tracking-[0.2em] text-green-300/80 uppercase">
 							Then the team
 						</p>
 						<h2 className="mt-3 text-2xl font-semibold tracking-tight md:text-3xl 2xl:text-4xl">
@@ -207,7 +208,7 @@ function InspectBeat() {
 			<div className="grid grid-cols-1 items-center gap-8 lg:grid-cols-2 lg:gap-10">
 				<Reveal>
 					<div className="max-w-md">
-						<p className="font-mono text-xs tracking-[0.2em] text-neutral-600 uppercase">
+						<p className="font-mono text-xs tracking-[0.2em] text-green-300/80 uppercase">
 							See without Rhino
 						</p>
 						<h2 className="mt-3 text-2xl font-semibold tracking-tight md:text-3xl 2xl:text-4xl">
@@ -220,7 +221,7 @@ function InspectBeat() {
 						</p>
 						<Link
 							to="/duckerweb"
-							className="mt-4 inline-flex items-center gap-1.5 text-sm text-neutral-300 underline-offset-4 hover:text-white hover:underline"
+							className="mt-4 inline-flex items-center gap-1.5 text-sm text-green-300 underline-offset-4 hover:text-green-200 hover:underline"
 						>
 							Open DuckerWeb
 							<ArrowRight className="h-3.5 w-3.5" />
@@ -241,7 +242,8 @@ function Closing() {
 			<Reveal>
 				<div className="mx-auto max-w-2xl text-center">
 					<h2 className="text-2xl font-semibold tracking-tight md:text-4xl">
-						Keep. Share. See.
+						Keep. Share.{" "}
+						<span className="text-green-300">See.</span>
 					</h2>
 					<p className="mt-3 text-base text-neutral-400 md:text-lg">
 						Your snippets stay organized. Your team gets a link. Anyone can read
@@ -251,7 +253,7 @@ function Closing() {
 						<SignUpButton mode="modal">
 							<button
 								type="button"
-								className="inline-flex items-center gap-2 rounded-full bg-white px-7 py-3.5 text-sm font-semibold text-black transition-all hover:bg-neutral-200 md:text-base"
+								className="inline-flex items-center gap-2 rounded-full bg-green-300 px-7 py-3.5 text-sm font-semibold text-neutral-800 transition-all hover:bg-green-200 md:text-base"
 							>
 								Get started
 								<ArrowRight className="h-4 w-4" />
@@ -261,7 +263,7 @@ function Closing() {
 							Just need a quick look?{" "}
 							<Link
 								to="/duckerweb"
-								className="text-neutral-300 underline-offset-4 hover:text-white hover:underline"
+								className="text-green-300 underline-offset-4 hover:text-green-200 hover:underline"
 							>
 								Open DuckerWeb
 							</Link>


### PR DESCRIPTION
## Summary
- Reframe the LP from review-first to **keep → share → see**: personal clip library, one-click share, then DuckerWeb inspect/diff
- Add restrained in-page copy/share demos that mirror Hopper Card UI (rings, tag chips, green-300 Shared badge)
- Warm the page with product accents (`green-300` CTAs, section labels, Shared badge) without leaving the dark theme
- Brand once: header owns “Hopper Clip”; hero leads with the job headline
- Demote DuckerWeb out of the hero; name it in the inspect beat with a direct link

## Test plan
- [ ] Open `/` signed out — brand only in header; hero is the job line + library preview
- [ ] Try copy / share demos; confirm green-300 feedback matches card language
- [ ] Inspect beat mentions DuckerWeb and links to `/duckerweb`
- [ ] Diff visual stays dark (fits LP); spacing feels tight on mobile + desktop
- [ ] Signed-in users still redirect to `/ghcards`