### PR TITLE
fix(csp): allow Shiki WASM with wasm-unsafe-eval

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,7 +33,8 @@ function buildSecurityHeaders({
 		// hydration scripts and several routes are prerendered to static HTML, so
 		// per-request nonces can never match (Clerk also requires it without a full
 		// strict-dynamic setup). 'unsafe-eval' is only needed by Vite's dev transforms.
-		`script-src 'self' 'unsafe-inline'${dev ? " 'unsafe-eval'" : ""} https://*.clerk.accounts.dev https://*.clerk.com https://clerk.hopperclip.com https://challenges.cloudflare.com https://us-assets.i.posthog.com`,
+		// 'wasm-unsafe-eval' is required by Shiki's Oniguruma WASM highlighter.
+		`script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'${dev ? " 'unsafe-eval'" : ""} https://*.clerk.accounts.dev https://*.clerk.com https://clerk.hopperclip.com https://challenges.cloudflare.com https://us-assets.i.posthog.com`,
 		"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
 		"font-src 'self' https://fonts.gstatic.com data:",
 		"img-src 'self' data: blob: https:",


### PR DESCRIPTION
## Summary
- Production CSP `script-src` blocked Shiki's Oniguruma WebAssembly highlighter (`Missing 'wasm-unsafe-eval' or 'unsafe-eval'`).
- Add `'wasm-unsafe-eval'` so syntax highlighting works without enabling full `'unsafe-eval'` in production.

## Test plan
- [ ] Open a GH/script view that uses Shiki highlighting in production (or a production build with CSP headers)
- [ ] Confirm no CSP console error about WebAssembly / `wasm-unsafe-eval`
- [ ] Confirm code blocks highlight correctly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for browser features that require WebAssembly execution.
  * Updated security policy handling to support WebAssembly without changing public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->